### PR TITLE
Revert "fei_hevc: Add control to use AVC VME to do intra prediction for HEVC FEI"

### DIFF
--- a/va/va_fei_hevc.h
+++ b/va/va_fei_hevc.h
@@ -165,9 +165,7 @@ typedef struct _VAEncMiscParameterFEIFrameControlHEVC
     uint32_t      search_window             : 8;
     /** \brief number of internal MV predictors for IME searches */
     uint32_t      max_num_ime_search_center : 3;
-    /** \brief only use AVC VME to do intra prediction */
-    uint32_t      use_avc_intra_mode_only   : 1;
-    uint32_t      reserved2                 : 4;
+    uint32_t      reserved2                 : 5;
 
     /** \brief specifies number of splits that encoder could be run concurrently
      * 1: level 1, default value


### PR DESCRIPTION
Reverts intel/libva#174

This is not a common usage, so revert it. 