### PR TITLE
Enable DRI3 support for libva

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -249,8 +249,8 @@ if test "$USE_X11:$enable_dri3" = "no:yes"; then
 fi
 
 if test "$enable_dri3" != "no"; then
-    PKG_CHECK_MODULES([DRI3], [xcb x11-xcb xcb-dri3 xcb-sync xshmfence],
-[USE_DRI3="yes"], [:])
+    PKG_CHECK_MODULES([DRI3], [xcb x11-xcb xcb-dri3 xcb-sync  \
+       xshmfence xcb-present], [USE_DRI3="yes"], [:])
 
     if test "x$USE_DRI3" = "xno" -a "x$enable_dri3" = "xyes"; then
        AC_MSG_ERROR([VA/X11-dri3 explicitly enabled, however $DRI3_PKG_ERRORS])

--- a/configure.ac
+++ b/configure.ac
@@ -139,6 +139,11 @@ AC_ARG_ENABLE(x11,
                     [build with VA/X11 API support @<:@default=auto@:>@])],
     [], [enable_x11="auto"])
 
+AC_ARG_ENABLE(dri3,
+    [AC_HELP_STRING([--enable-dri3],
+                    [build with VA/X11-DRI3 API support @<:@default=no@:>@])],
+    [], [enable_dri3="no"])
+
 AC_ARG_ENABLE(glx,
     [AC_HELP_STRING([--enable-glx],
                     [build with VA/GLX API support @<:@default=auto@:>@])],
@@ -236,6 +241,28 @@ if test "x$enable_x11" != "xno"; then
 fi
 AM_CONDITIONAL(USE_X11, test "$USE_X11" = "yes")
 
+# Check for DRI3
+USE_DRI3="no"
+
+if test "$USE_X11:$enable_dri3" = "no:yes"; then
+    AC_MSG_ERROR([VA/X11-DRI3 explicitly enabled, but VA/X11 isn't built])
+fi
+
+if test "$enable_dri3" != "no"; then
+    PKG_CHECK_MODULES([DRI3], [xcb x11-xcb xcb-dri3 xcb-sync xshmfence],
+[USE_DRI3="yes"], [:])
+
+    if test "x$USE_DRI3" = "xno" -a "x$enable_dri3" = "xyes"; then
+       AC_MSG_ERROR([VA/X11-dri3 explicitly enabled, however $DRI3_PKG_ERRORS])
+    fi
+
+    if test "$USE_DRI3" = "yes"; then
+       AC_DEFINE([HAVE_VA_DRI3], [1], [Defined to 1 if VA/X11-DRI3 API \
+	is built])
+    fi
+fi
+AM_CONDITIONAL(USE_DRI3, test "$USE_DRI3" = "yes")
+
 # Check for GLX
 USE_GLX="no"
 
@@ -322,6 +349,7 @@ AC_OUTPUT([
 BACKENDS=""
 AS_IF([test x$USE_DRM = xyes], [BACKENDS="$BACKENDS drm"])
 AS_IF([test x$USE_X11 = xyes], [BACKENDS="$BACKENDS x11"])
+AS_IF([test x$USE_DRI3 = xyes], [BACKENDS="$BACKENDS x11-dri3"])
 AS_IF([test x$USE_GLX = xyes], [BACKENDS="$BACKENDS glx"])
 AS_IF([test x$USE_WAYLAND = xyes], [BACKENDS="$BACKENDS wayland"])
 

--- a/va/Makefile.am
+++ b/va/Makefile.am
@@ -103,6 +103,9 @@ libva_x11_la_LDFLAGS		= $(LDADD)
 libva_x11_la_DEPENDENCIES	= libva.la x11/libva_x11.la
 libva_x11_la_LIBADD		= libva.la x11/libva_x11.la \
 	$(LIBVA_LIBS) $(X11_LIBS) $(XEXT_LIBS) $(XFIXES_LIBS) $(DRM_LIBS) -ldl
+if USE_DRI3
+libva_x11_la_LIBADD		+= $(DRI3_LIBS) -ldl
+endif
 endif
 
 if USE_GLX

--- a/va/x11/Makefile.am
+++ b/va/x11/Makefile.am
@@ -48,6 +48,15 @@ source_h_priv = \
 	va_nvctrl.h		\
 	$(NULL)
 
+if USE_DRI3
+source_c += \
+	dri3_util.c		\
+	va_dri3.c		\
+	$(NULL)
+source_h += \
+	va_dri3.h
+endif
+
 noinst_LTLIBRARIES		= libva_x11.la	
 libva_x11includedir		= ${includedir}/va
 libva_x11include_HEADERS	= $(source_h)

--- a/va/x11/dri3_util.c
+++ b/va/x11/dri3_util.c
@@ -45,6 +45,32 @@ va_dri3_createPixmap(VADriverContextP ctx, Drawable draw,
                                  stride, size);
 }
 
+void
+va_dri3_presentPixmap(VADriverContextP ctx,
+                      Drawable draw,
+                      Pixmap pixmap,
+                      unsigned int serial,
+                      xcb_xfixes_region_t valid,
+                      xcb_xfixes_region_t update,
+                      unsigned short int x_off,
+                      unsigned short int y_off,
+                      xcb_randr_crtc_t target_crtc,
+                      xcb_sync_fence_t wait_fence,
+                      xcb_sync_fence_t idle_fence,
+                      unsigned int options,
+                      unsigned long int target_msc,
+                      unsigned long int divisor,
+                      unsigned long int  remainder,
+                      unsigned int notifies_len,
+                      const xcb_present_notify_t *notifies)
+{
+    VA_DRI3_present_pixmap(ctx->native_dpy, draw,
+                           pixmap, serial, valid, update,
+                           x_off, y_off, target_crtc, wait_fence,
+                           idle_fence, options, target_msc, divisor,
+                           remainder, notifies_len, notifies);
+}
+
 int
 va_dri3_create_fence(VADriverContextP ctx, Pixmap pixmap,
                      struct dri3_fence *fence)

--- a/va/x11/dri3_util.c
+++ b/va/x11/dri3_util.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2018 Intel Corporation. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sub license, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+ * IN NO EVENT SHALL PRECISION INSIGHT AND/OR ITS SUPPLIERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <fcntl.h>
+#include <X11/Xlibint.h>
+#include <unistd.h>
+
+#include "va_dri3.h"
+
+int
+va_dri3_createfd(VADriverContextP ctx, Pixmap pixmap, int *stride)
+{
+    return VA_DRI3_create_fd(ctx->native_dpy, pixmap, stride);
+}
+
+Pixmap
+va_dri3_createPixmap(VADriverContextP ctx, Drawable draw,
+                     int width, int height, int depth,
+                     int fd, int bpp, int stride, int size)
+{
+    return VA_DRI3_create_pixmap(ctx->native_dpy,
+                                 draw, width, height,
+                                 depth, fd, bpp,
+                                 stride, size);
+}
+
+int
+va_dri3_create_fence(VADriverContextP ctx, Pixmap pixmap,
+                     struct dri3_fence *fence)
+{
+    return VA_DRI3_create_fence(ctx->native_dpy, pixmap, fence);
+}
+
+void va_dri3_fence_sync(VADriverContextP ctx, struct dri3_fence *fence)
+{
+    VA_DRI3_fence_sync(ctx->native_dpy, fence);
+}
+
+void va_dri3_fence_free(VADriverContextP ctx, struct dri3_fence *fence)
+{
+    VA_DRI3_fence_free(ctx->native_dpy, fence);
+}
+
+void
+va_dri3_close(VADriverContextP ctx)
+{
+    struct dri_state *dri_state = (struct dri_state *)ctx->drm_state;
+    if(dri_state->base.fd >= 0)
+        close(dri_state->base.fd);
+}
+
+Bool
+va_isDRI3Connected(VADriverContextP ctx, char** driver_name)
+{
+    struct dri_state *dri_state = (struct dri_state *)ctx->drm_state;
+    char *device_name = NULL;
+    *driver_name = NULL;
+    dri_state->base.fd = -1;
+    dri_state->base.auth_type = VA_DRM_AUTH_CUSTOM;
+
+    if(!VA_DRI3Connect(ctx->native_dpy, driver_name, &device_name))
+            goto err_out;
+
+    dri_state->base.fd = open(device_name, O_RDWR);
+
+    if(dri_state->base.fd < 0)
+        goto err_out;
+
+    dri_state->createfd         = va_dri3_createfd;
+    dri_state->createPixmap     = va_dri3_createPixmap;
+    dri_state->close            = va_dri3_close;
+    dri_state->create_fence     = va_dri3_create_fence;
+    dri_state->fence_free       = va_dri3_fence_free;
+    dri_state->fence_sync       = va_dri3_fence_sync;
+
+    Xfree(device_name);
+
+    return True;
+
+err_out:
+    if(device_name)
+        Xfree(device_name);
+    if(*driver_name)
+        Xfree(*driver_name);
+    if(dri_state->base.fd >= 0)
+        close(dri_state->base.fd);
+    dri_state->base.fd = -1;
+
+    return False;
+}

--- a/va/x11/va_dri3.c
+++ b/va/x11/va_dri3.c
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "va_dri3.h"
+
+Pixmap VA_DRI3_create_pixmap(Display *dpy,
+                             Drawable draw,
+                             int width, int height, int depth,
+                             int fd, int bpp, int stride, int size)
+{
+    xcb_connection_t *c = XGetXCBConnection(dpy);
+    if (fd >= 0) {
+        xcb_pixmap_t pixmap = xcb_generate_id(c);
+        xcb_dri3_pixmap_from_buffer(c, pixmap, draw, size, width, height,
+                                    stride, depth, bpp, fd);
+        return pixmap;
+    }
+    return 0;
+}
+
+int VA_DRI3_create_fd(Display *dpy, Pixmap pixmap, int *stride)
+{
+    xcb_connection_t *c = XGetXCBConnection(dpy);
+    xcb_dri3_buffer_from_pixmap_cookie_t cookie;
+    xcb_dri3_buffer_from_pixmap_reply_t *reply;
+
+    cookie = xcb_dri3_buffer_from_pixmap(c, pixmap);
+    reply = xcb_dri3_buffer_from_pixmap_reply(c, cookie, NULL);
+    if (!reply) {
+        return -1;
+    }
+
+    if (reply->nfd != 1) {
+        free(reply);
+        return -1;
+    }
+
+    *stride = reply->stride;
+    return xcb_dri3_buffer_from_pixmap_reply_fds(c, reply)[0];
+}
+
+static void VA_DRI3_query_version(xcb_connection_t *c, int *major, int *minor)
+{
+    xcb_dri3_query_version_reply_t *reply;
+
+    reply = xcb_dri3_query_version_reply(c,
+                                         xcb_dri3_query_version(c,
+                                         XCB_DRI3_MAJOR_VERSION,
+                                         XCB_DRI3_MINOR_VERSION),
+                NULL);
+    if (reply != NULL) {
+        *major = reply->major_version;
+        *minor = reply->minor_version;
+        free(reply);
+    }
+}
+
+int
+VA_DRI3_create_fence(Display *dpy, Pixmap pixmap, struct dri3_fence *fence)
+{
+    xcb_connection_t *c = XGetXCBConnection(dpy);
+    struct dri3_fence f;
+    int fd;
+
+    fd = xshmfence_alloc_shm();
+    if (fd < 0) {
+        return -1;
+    }
+
+    f.addr = xshmfence_map_shm(fd);
+    if (f.addr == NULL) {
+        close(fd);
+        return -1;
+    }
+
+    f.xid = xcb_generate_id(c);
+    xcb_dri3_fence_from_fd(c, pixmap, f.xid, 0, fd);
+
+    *fence = f;
+    return 0;
+}
+
+void VA_DRI3_fence_sync(Display *dpy, struct dri3_fence *fence)
+{
+    xcb_connection_t *c = XGetXCBConnection(dpy);
+
+    xshmfence_reset(fence->addr);
+
+    xcb_sync_trigger_fence(c, fence->xid);
+    xcb_flush(c);
+
+    xshmfence_await(fence->addr);
+}
+
+void VA_DRI3_fence_free(Display *dpy, struct dri3_fence *fence)
+{
+    xcb_connection_t *c = XGetXCBConnection(dpy);
+
+    xshmfence_unmap_shm(fence->addr);
+    xcb_sync_destroy_fence(c, fence->xid);
+}
+
+static int VA_DRI3_exists(xcb_connection_t *c)
+{
+    const xcb_query_extension_reply_t *ext;
+    int major, minor;
+
+    major = minor = -1;
+
+    ext = xcb_get_extension_data(c, &xcb_dri3_id);
+    if (ext != NULL)
+        VA_DRI3_query_version(c, &major, &minor);
+
+    return major >= 0;
+}
+
+int VA_DRI3_open(Display *dpy, Window root, unsigned provider)
+{
+    xcb_connection_t *c = XGetXCBConnection(dpy);
+    xcb_dri3_open_cookie_t cookie;
+    xcb_dri3_open_reply_t *reply;
+
+    if (!VA_DRI3_exists(c)) {
+        return -1;
+    }
+
+    cookie = xcb_dri3_open(c, root, provider);
+    reply = xcb_dri3_open_reply(c, cookie, NULL);
+
+    if (!reply) {
+        return -1;
+    }
+
+    if (reply->nfd != 1) {
+        free(reply);
+        return -1;
+    }
+
+    return xcb_dri3_open_reply_fds(c, reply)[0];
+}
+
+struct driver_name_map {
+    const char *key;
+    int         key_len;
+    const char *name;
+};
+
+static const struct driver_name_map g_driver_name_map[] = {
+    { "i915",       4, "i965"   },   // Intel OTC GenX driver
+    { "pvrsrvkm",   8, "pvr"    },   // Intel UMG PVR driver
+    { "emgd",       4, "emgd"   },   // Intel ECG PVR driver
+    { "hybrid",     6, "hybrid" },   // Intel OTC Hybrid driver
+    { "nouveau",    7, "nouveau"  }, // Mesa Gallium driver
+    { "radeon",     6, "r600"     }, // Mesa Gallium driver
+    { "amdgpu",     6, "radeonsi" }, // Mesa Gallium driver
+    { NULL, }
+};
+
+Bool
+VA_DRI3Connect(Display *dpy, char** driver_name, char** device_name)
+{
+    const struct driver_name_map *m;
+    drmVersionPtr drm_version;
+    int fd = VA_DRI3_open(dpy,
+                          RootWindow(dpy, DefaultScreen(dpy)),
+                          None);
+    if(fd != -1) {
+        *device_name = drmGetRenderDeviceNameFromFd(fd);
+
+        drm_version = drmGetVersion(fd);
+        if (!drm_version)
+            return 0;
+
+        for (m = g_driver_name_map; m->key != NULL; m++) {
+            if (drm_version->name_len >= m->key_len &&
+                strncmp(drm_version->name, m->key, m->key_len) == 0)
+                break;
+        }
+        drmFreeVersion(drm_version);
+
+        if (!m->name)
+            return 0;
+    }
+    else
+        return 0;
+
+    *driver_name = strdup(m->name);
+    fcntl(fd, F_SETFD, FD_CLOEXEC);
+
+    return 1;
+}

--- a/va/x11/va_dri3.h
+++ b/va/x11/va_dri3.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#ifndef VA_DRI3_H
+#define VA_DRI3_H
+
+#include <X11/Xlib-xcb.h>
+#include <xcb/dri3.h>
+#include <xcb/sync.h>
+#include <X11/xshmfence.h>
+
+#include "va_dricommon.h"
+
+int VA_DRI3_open(Display *dpy, Window root, unsigned provider);
+Pixmap VA_DRI3_create_pixmap(Display *dpy, Drawable draw, int width,
+                             int height, int depth, int fd, int bpp,
+                             int stride, int size);
+int VA_DRI3_create_fd(Display *dpy, Pixmap pixmap, int *stride);
+Bool VA_DRI3Connect(Display *dpy, char** driver_name, char** device_name);
+
+int
+VA_DRI3_create_fence(Display *dpy, Pixmap pixmap, struct dri3_fence *fence);
+void VA_DRI3_fence_sync(Display *dpy, struct dri3_fence *fence);
+void VA_DRI3_fence_free(Display *dpy, struct dri3_fence *fence);
+
+#endif /* VA_DRI3_H */

--- a/va/x11/va_dri3.h
+++ b/va/x11/va_dri3.h
@@ -43,5 +43,22 @@ int
 VA_DRI3_create_fence(Display *dpy, Pixmap pixmap, struct dri3_fence *fence);
 void VA_DRI3_fence_sync(Display *dpy, struct dri3_fence *fence);
 void VA_DRI3_fence_free(Display *dpy, struct dri3_fence *fence);
-
+void
+VA_DRI3_present_pixmap(Display *dpy,
+                       xcb_window_t window,
+                       xcb_pixmap_t pixmap,
+                       unsigned int serial,
+                       xcb_xfixes_region_t valid,
+                       xcb_xfixes_region_t update,
+                       unsigned short int x_off,
+                       unsigned short int y_off,
+                       xcb_randr_crtc_t target_crtc,
+                       xcb_sync_fence_t wait_fence,
+                       xcb_sync_fence_t idle_fence,
+                       unsigned int options,
+                       unsigned long int target_msc,
+                       unsigned long int divisor,
+                       unsigned long int  remainder,
+                       unsigned int notifies_len,
+                       const xcb_present_notify_t *notifies);
 #endif /* VA_DRI3_H */

--- a/va/x11/va_dricommon.h
+++ b/va/x11/va_dricommon.h
@@ -71,6 +71,11 @@ struct dri_drawable
     struct dri_drawable *next;
 };
 
+struct dri3_fence {
+    XID xid;
+    void *addr;
+};
+
 #define DRAWABLE_HASH_SZ 32
 struct dri_state 
 {
@@ -83,6 +88,16 @@ struct dri_state
     void (*swapBuffer)(VADriverContextP ctx, struct dri_drawable *dri_drawable);
     union dri_buffer *(*getRenderingBuffer)(VADriverContextP ctx, struct dri_drawable *dri_drawable);
     void (*close)(VADriverContextP ctx);
+    int (*createfd)(VADriverContextP ctx, Pixmap pixmap, int *stride);
+    Pixmap
+    (*createPixmap)(VADriverContextP ctx, Drawable draw,
+                    int width, int height, int depth,
+                    int fd, int bpp, int stride, int size);
+    int
+    (*create_fence)(VADriverContextP ctx, Pixmap pixmap,
+                         struct dri3_fence *fence);
+    void (*fence_sync)(VADriverContextP ctx, struct dri3_fence *fence);
+    void (*fence_free)(VADriverContextP ctx, struct dri3_fence *fence);
 #endif
     /** \brief Reserved bytes for future use, must be zero */
     unsigned long  va_reserved[16];
@@ -94,5 +109,20 @@ void va_dri_free_drawable_hashtable(VADriverContextP ctx);
 struct dri_drawable *va_dri_get_drawable(VADriverContextP ctx, XID drawable);
 void va_dri_swap_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable);
 union dri_buffer *va_dri_get_rendering_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable);
+
+#ifdef HAVE_VA_DRI3
+Bool va_isDRI3Connected(VADriverContextP ctx, char **driver_name);
+Pixmap
+va_dri3_createPixmap(VADriverContextP ctx, Drawable draw,
+                     int width, int height, int depth,
+                     int fd, int bpp, int stride, int size);
+int va_dri3_createfd(VADriverContextP ctx, Pixmap pixmap, int *stride);
+void va_dri3_close(VADriverContextP ctx);
+int
+va_dri3_create_fence(VADriverContextP ctx, Pixmap pixmap,
+                     struct dri3_fence *fence);
+void va_dri3_fence_sync(VADriverContextP ctx, struct dri3_fence *fence);
+void va_dri3_fence_free(VADriverContextP ctx, struct dri3_fence *fence);
+#endif
 
 #endif /* _VA_DRICOMMON_H_ */

--- a/va/x11/va_dricommon.h
+++ b/va/x11/va_dricommon.h
@@ -33,6 +33,7 @@
 
 #include <va/va_backend.h>
 #include <va/va_drmcommon.h>
+#include <xcb/present.h>
 
 #ifdef ANDROID
 #define XID unsigned int
@@ -93,6 +94,21 @@ struct dri_state
     (*createPixmap)(VADriverContextP ctx, Drawable draw,
                     int width, int height, int depth,
                     int fd, int bpp, int stride, int size);
+    void (*presentPixmap)(VADriverContextP ctx, Drawable draw,
+                          Pixmap pixmap, unsigned int serial,
+                          xcb_xfixes_region_t valid,
+                          xcb_xfixes_region_t update,
+                          unsigned short int x_off,
+                          unsigned short int y_off,
+                          xcb_randr_crtc_t target_crtc,
+                          xcb_sync_fence_t wait_fence,
+                          xcb_sync_fence_t idle_fence,
+                          unsigned int options,
+                          unsigned long int target_msc,
+                          unsigned long int divisor,
+                          unsigned long int  remainder,
+                          unsigned int notifies_len,
+                          const xcb_present_notify_t *notifies);
     int
     (*create_fence)(VADriverContextP ctx, Pixmap pixmap,
                          struct dri3_fence *fence);
@@ -117,6 +133,22 @@ va_dri3_createPixmap(VADriverContextP ctx, Drawable draw,
                      int width, int height, int depth,
                      int fd, int bpp, int stride, int size);
 int va_dri3_createfd(VADriverContextP ctx, Pixmap pixmap, int *stride);
+void
+va_dri3_presentPixmap(VADriverContextP ctx, Drawable draw,
+                      Pixmap pixmap, unsigned int serial,
+                      xcb_xfixes_region_t valid,
+                      xcb_xfixes_region_t update,
+                      unsigned short int x_off,
+                      unsigned short int y_off,
+                      xcb_randr_crtc_t target_crtc,
+                      xcb_sync_fence_t wait_fence,
+                      xcb_sync_fence_t idle_fence,
+                      unsigned int options,
+                      unsigned long int target_msc,
+                      unsigned long int divisor,
+                      unsigned long int  remainder,
+                      unsigned int notifies_len,
+                      const xcb_present_notify_t *notifies);
 void va_dri3_close(VADriverContextP ctx);
 int
 va_dri3_create_fence(VADriverContextP ctx, Pixmap pixmap,

--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -73,6 +73,20 @@ static void va_DisplayContextDestroy (
     free(pDisplayContext);
 }
 
+#ifdef HAVE_VA_DRI3
+static VAStatus va_DRI3GetDriverName (
+    VADisplayContextP pDisplayContext,
+    char **driver_name
+)
+{
+    VADriverContextP ctx = pDisplayContext->pDriverContext;
+
+    if (!va_isDRI3Connected(ctx, driver_name))
+        return VA_STATUS_ERROR_UNKNOWN;
+
+    return VA_STATUS_SUCCESS;
+}
+#endif
 
 static VAStatus va_DRI2GetDriverName (
     VADisplayContextP pDisplayContext,
@@ -139,7 +153,11 @@ static VAStatus va_DisplayContextGetDriverName (
 	*driver_name = NULL;
     else
         return VA_STATUS_ERROR_UNKNOWN;
-    
+
+#ifdef HAVE_VA_DRI3
+    vaStatus = va_DRI3GetDriverName(pDisplayContext, driver_name);
+    if (vaStatus != VA_STATUS_SUCCESS)
+#endif
     vaStatus = va_DRI2GetDriverName(pDisplayContext, driver_name);
     if (vaStatus != VA_STATUS_SUCCESS)
         vaStatus = va_NVCTRL_GetDriverName(pDisplayContext, driver_name);


### PR DESCRIPTION
vaInitialize used to fail when Xwayland is running blocking VA-API in Gnome Shell on Wayland.
Root cause was that libva only supported DRI2 whereas Xwayland only supported DRI3.
https://github.com/intel/libva/issues/79 

This pull request enables support for DRI3 protocol for Direct Rendering via libva. With this libva supports standard dri3 apis which dri clients can utilize.

The thing to take care of is that under DRI3 clients allocate themselves their render buffers instead of relying on the X Server for doing the allocation. 

Use --enable-dri3 flag to enable this feature.