### PR TITLE
va: add new VA STATUS ERROR

### DIFF
--- a/va/va.c
+++ b/va/va.c
@@ -594,6 +594,8 @@ const char *vaErrorStr(VAStatus error_status)
             return "HW busy now";
         case VA_STATUS_ERROR_UNSUPPORTED_MEMORY_TYPE:
             return "an unsupported memory type was supplied";
+        case VA_STATUS_ERROR_NOT_ENOUGH_BUFFER:
+            return "allocated memory size is not enough for input or output";
         case VA_STATUS_ERROR_UNKNOWN:
             return "unknown libva error";
     }

--- a/va/va.h
+++ b/va/va.h
@@ -210,6 +210,8 @@ typedef int VAStatus;	/** Return status type from functions */
 #define VA_STATUS_ERROR_HW_BUSY	                0x00000022
 /** \brief An unsupported memory type was supplied. */
 #define VA_STATUS_ERROR_UNSUPPORTED_MEMORY_TYPE 0x00000024
+/** \brief Indicate allocated buffer size is not enough for input or output. */
+#define VA_STATUS_ERROR_NOT_ENOUGH_BUFFER       0x00000025
 #define VA_STATUS_ERROR_UNKNOWN			0xFFFFFFFF
 
 /** De-interlacing flags for vaPutSurface() */


### PR DESCRIPTION
Add new VA STATUS ERROR to indicate allocated buffer size is
not enough for input or output.

Signed-off-by: ChenXiaomin <xiaomin.chen@intel.com>