### PR TITLE
va: Add VA_SURFACE_ATTRIB_USAGE_HINT_EXPORT

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -1321,6 +1321,9 @@ typedef struct _VASurfaceAttribExternalBuffers {
 #define VA_SURFACE_ATTRIB_USAGE_HINT_VPP_WRITE 	0x00000008
 /** \brief Surface used for display. */
 #define VA_SURFACE_ATTRIB_USAGE_HINT_DISPLAY 	0x00000010
+/** \brief Surface used for export to third-party APIs, e.g. via
+ *  vaExportSurfaceHandle(). */
+#define VA_SURFACE_ATTRIB_USAGE_HINT_EXPORT 	0x00000020
 
 /**@}*/
 


### PR DESCRIPTION
This can be used to tell the driver to prepare the surface such
that it can easily be used for export to third-party APIs.
For example, the driver might choose to decode to frames instead
of fields since only frames can be exported.

AMD driver could make use of this so it doesn't have to weave for export.
See https://bugs.freedesktop.org/show_bug.cgi?id=105145 for more motivational background