### PR TITLE
Return once the drawable is destroyed

### DIFF
--- a/va/x11/va_dricommon.c
+++ b/va/x11/va_dricommon.c
@@ -90,6 +90,7 @@ va_dri_free_drawable(VADriverContextP ctx, struct dri_drawable* dri_drawable)
 	if (dri_drawable == dri_state->drawable_hash[i]) {
 	    dri_state->destroyDrawable(ctx, dri_drawable);
 	    dri_state->drawable_hash[i] = NULL;
+	    return;
 	}
 	i++;
     }


### PR DESCRIPTION
Otherwise it might dereference a freed pointer in the next loop
