### PR TITLE
Use the new link URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
 addons:
   coverity_scan:
     project:
-      name: "01org/libva"
+      name: "intel/libva"
       description: "Build submitted via Travis CI"
     notification_email: intel-media-security@lists.01.org
     build_command_prepend: "./autogen.sh; ./configure --prefix=/usr"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,11 @@ We accept github pull requests.
 
 Once you've finished making your changes push them to your fork and send the PR via the github UI.
 
-## Issue tracking
+## Reporting a security issue
+
+Please mail to secure-opensource@intel.com directly for security issue
+
+## Public issue tracking
 
 If you have a problem, please let us know.  IRC is a perfectly fine place
 to quickly informally bring something up, if you get a response.  The
@@ -53,14 +57,14 @@ to quickly informally bring something up, if you get a response.  The
 is a more durable communication channel.
 
 If it's a bug not already documented, by all means please [open an
-issue in github](https://github.com/01org/libva/issues/new) so we all get visibility
+issue in github](https://github.com/intel/libva/issues/new) so we all get visibility
 to the problem and can work towards a resolution.
 
 For feature requests we're also using github issues, with the label
 "enhancement".
 
 Our github bug/enhancement backlog and work queue are tracked in a
-[Libva waffle.io kanban](https://waffle.io/01org/libva).
+[Libva waffle.io kanban](https://waffle.io/intel/libva).
 
 ## Closing issues
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Stories in Ready](https://badge.waffle.io/01org/libva.png?label=ready&title=Ready)](http://waffle.io/01org/libva)
-[![Build Status](https://travis-ci.org/01org/libva.svg?branch=master)](https://travis-ci.org/01org/libva)
-[![Coverity Scan Build Status](https://scan.coverity.com/projects/11605/badge.svg)](https://scan.coverity.com/projects/01org-libva)
+[![Stories in Ready](https://badge.waffle.io/intel/libva.png?label=ready&title=Ready)](http://waffle.io/intel/libva)
+[![Build Status](https://travis-ci.org/intel/libva.svg?branch=master)](https://travis-ci.org/intel/libva)
+[![Coverity Scan Build Status](https://scan.coverity.com/projects/11605/badge.svg)](https://scan.coverity.com/projects/intel-libva)
 
 # Libva Project
 
@@ -13,10 +13,10 @@ driver-specific acceleration backends for each supported hardware
 vendor.
 
 If you would like to contribute to libva, check our [Contributing
-guide](https://github.com/01org/libva/blob/master/CONTRIBUTING.md).
+guide](https://github.com/intel/libva/blob/master/CONTRIBUTING.md).
 
 We also recommend taking a look at the ['janitorial'
-bugs](https://github.com/01org/libva/issues?q=is%3Aopen+is%3Aissue+label%3AJanitorial)
+bugs](https://github.com/intel/libva/issues?q=is%3Aopen+is%3Aissue+label%3AJanitorial)
 in our list of open issues as these bugs can be solved without an
 extensive knowledge of libva.
 
@@ -24,7 +24,7 @@ We would love to help you start contributing!
 
 Doxygen files are regularly updated through Github Pages and can
 be accessed directly through [github pages
-libva](http://01org.github.io/libva/)
+libva](http://intel.github.io/libva/)
 
 The libva development team can be reached via our [mailing
 list](https://lists.01.org/mailman/listinfo/intel-vaapi-media) and on IRC

--- a/configure.ac
+++ b/configure.ac
@@ -84,9 +84,9 @@ m4_define([wayland_api_version], [1.11.0])
 AC_PREREQ(2.57)
 AC_INIT([libva],
         [libva_version],
-        [https://github.com/01org/libva/issues/new],
+        [https://github.com/intel/libva/issues/new],
         [libva],
-        [https://github.com/01org/libva])
+        [https://github.com/intel/libva])
 
 AC_CONFIG_SRCDIR([Makefile.am])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
We moved libva from github/01org to github/intel, however some files
still have links to the old 01org URLs, this commit updates these links
to the new intel URLs. In addition, this commit added a contact email
address for security issue reporting

This fixes https://github.com/intel/libva/issues/189

