### PR TITLE
Fix issue with static analysis scan

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -86,7 +86,7 @@
 extern "C" {
 #endif
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__COVERITY__)
 #define va_deprecated __attribute__((deprecated))
 #if __GNUC__ >= 6
 #define va_deprecated_enum va_deprecated


### PR DESCRIPTION
Coverity fails to parse the expanded value of
va_deprecated and causes the scan to abort.  This
problem also affects downstream dependents of
va.h that get scanned with coverity, too.  This
results in only partially-scanned code with the
following coverity errors:
```
"../../va/va.h", line 361: error #67: expected a "}"
      VAProfileH264Baseline va_deprecated_enum = 5,
                            ^
```
To fix this, we don't need to define a value for
va_deprecated or va_deprecated_enum during a
coverity scan.