### PR TITLE
Check for -fstack-protector

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -209,6 +209,22 @@ if test "$ac_cv_have_gnuc_visibility_attribute" = "yes"; then
               [Defined to 1 if GCC visibility attribute is supported])
 fi
 
+# Check for -fstack-protector
+ssp_cc=yes
+if test "X$CC-cc" != "X"; then
+    AC_MSG_CHECKING([whether ${CC-cc} accepts -fstack-protector])
+    ssp_old_cflags="$CFLAGS"
+    CFLAGS="$CFLAGS -fstack-protector"
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[alloca(100);]])], [], [ssp_cc=no])
+    AC_MSG_RESULT([$ssp_cc])
+    if test "X$ssp_cc" = "Xno"; then
+        CFLAGS="$ssp_old_cflags"
+    else
+        AC_DEFINE([ENABLE_SSP_CC], 1, [Define if SSP C support is enabled.])
+    fi
+fi
+AM_CONDITIONAL(USE_SSP, test "$ssp_cc" = "yes")
+
 # Check for DRM (mandatory)
 LIBDRM_VERSION=libdrm_version
 PKG_CHECK_MODULES([DRM], [libdrm >= $LIBDRM_VERSION])

--- a/va/Makefile.am
+++ b/va/Makefile.am
@@ -77,8 +77,11 @@ libva_ldflags = \
 
 libva_cflags = \
 	-Wall			\
-	-fstack-protector	\
 	$(NULL)
+
+if USE_SSP
+libva_cflags += -fstack-protector
+endif
 
 lib_LTLIBRARIES			= libva.la
 libvaincludedir			= ${includedir}/va


### PR DESCRIPTION
Not all toolchains provide support for -fstack-protector. This patch
provides a configure check to avoid build errors like

/home/buildroot/buildroot/output/host/opt/ext-toolchain/bin/../lib/gcc/x86_64-buildroot-linux-uclibc/6.4.0/../../../../x86_64-buildroot-linux-uclibc/bin/ld: cannot find -lssp_nonshared
/home/buildroot/buildroot/output/host/opt/ext-toolchain/bin/../lib/gcc/x86_64-buildroot-linux-uclibc/6.4.0/../../../../x86_64-buildroot-linux-uclibc/bin/ld: cannot find -lssp