### PR TITLE
va: Add missing enum to string conversions

### DIFF
--- a/va/va_str.c
+++ b/va/va_str.c
@@ -171,6 +171,7 @@ const char *vaBufferTypeStr(VABufferType bufferType)
     TOSTR(VAStatsMVPredictorBufferType);
     TOSTR(VAEncFEICTBCmdBufferType);
     TOSTR(VAEncFEICURecordBufferType);
+    TOSTR(VASubsetsParameterBufferType);
     case VABufferTypeMax: break;
     }
     return "<unknown buffer type>";


### PR DESCRIPTION
VASubsetsParameterBufferType were added in commit dd20f1c5 but its
conversion to string was missing.

This patch adds it.