### PR TITLE
Fix compilation warning on Android

### DIFF
--- a/va/drm/va_drm_utils.c
+++ b/va/drm/va_drm_utils.c
@@ -44,7 +44,7 @@ static const struct driver_name_map g_driver_name_map[] = {
     { "nouveau",    7, "nouveau"  }, // Mesa Gallium driver
     { "radeon",     6, "r600"     }, // Mesa Gallium driver
     { "amdgpu",     6, "radeonsi" }, // Mesa Gallium driver
-    { NULL, }
+    { NULL,         0, NULL }
 };
 
 /* Returns the VA driver name for the active display */

--- a/va/va.c
+++ b/va/va.c
@@ -406,7 +406,7 @@ static VAStatus va_openDriver(VADisplay dpy, char *driver_name)
                 { VA_MAJOR_VERSION, 2 },
                 { VA_MAJOR_VERSION, 1 },
                 { VA_MAJOR_VERSION, 0 },
-                { -1, }
+                { -1, -1}
             };
 
             for (i = 0; compatible_versions[i].major >= 0; i++) {
@@ -943,7 +943,7 @@ va_impl_query_surface_attributes(
         { VASurfaceAttribMinHeight,     VAGenericValueTypeInteger },
         { VASurfaceAttribMaxHeight,     VAGenericValueTypeInteger },
         { VASurfaceAttribMemoryType,    VAGenericValueTypeInteger },
-        { VASurfaceAttribNone, }
+        { VASurfaceAttribNone,          VAGenericValueTypeInteger }
     };
 
     if (!out_attribs || !out_num_attribs_ptr)

--- a/va/va_fool.c
+++ b/va/va_fool.c
@@ -265,7 +265,7 @@ VAStatus va_FoolBufferInfo(
 static int va_FoolFillCodedBufEnc(VADisplay dpy, struct fool_context *fool_ctx)
 {
     char file_name[1024];
-    struct stat file_stat = {0};
+    struct stat file_stat = {};
     VACodedBufferSegment *codedbuf;
     int i, fd = -1;
     ssize_t ret;
@@ -311,7 +311,7 @@ static int va_FoolFillCodedBufEnc(VADisplay dpy, struct fool_context *fool_ctx)
 
 static int va_FoolFillCodedBufJPG(VADisplay dpy, struct fool_context *fool_ctx)
 {
-    struct stat file_stat = {0};
+    struct stat file_stat = {};
     VACodedBufferSegment *codedbuf;
     int fd = -1;
     ssize_t ret;

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -1134,7 +1134,7 @@ static void va_TraceSurfaceAttributes(
             va_TraceMsg(trace_ctx, "\t\tvalue.value.p = %p\n", p->value.value.p);
             if ((p->type == VASurfaceAttribExternalBufferDescriptor) && p->value.value.p) {
                 VASurfaceAttribExternalBuffers *tmp = (VASurfaceAttribExternalBuffers *) p->value.value.p;
-                int j;
+                uint32_t j;
                 
                 va_TraceMsg(trace_ctx, "\t\t--VASurfaceAttribExternalBufferDescriptor\n");
                 va_TraceMsg(trace_ctx, "\t\t  pixel_format=0x%08x\n", tmp->pixel_format);
@@ -4629,7 +4629,7 @@ va_TraceProcFilterParameterBuffer(
     unsigned int size;
     unsigned int num_elements;
     VAProcFilterParameterBufferBase *base_filter = NULL;
-    int i;
+    unsigned int i;
 
     DPY2TRACECTX(dpy, context, VA_INVALID_ID);
 
@@ -4694,7 +4694,7 @@ va_TraceVAProcPipelineParameterBuffer(
 )
 {
     VAProcPipelineParameterBuffer *p = (VAProcPipelineParameterBuffer *)data;
-    int i;
+    uint32_t i;
 
     DPY2TRACECTX(dpy, context, VA_INVALID_ID);
 


### PR DESCRIPTION
Fix compilation warning (uninit and wrong type variables) for libva 2.0 master on Android O MR1

Signed-off-by: Badiuzzaman Iskhandar <badiuzzaman.azzarfan.bin.iskhandar@intel.com>