### PR TITLE
drm: Add iHD to driver_name_map

### DIFF
--- a/va/drm/va_drm_utils.c
+++ b/va/drm/va_drm_utils.c
@@ -37,6 +37,7 @@ struct driver_name_map {
 };
 
 static const struct driver_name_map g_driver_name_map[] = {
+    { "i915",       4, "iHD"    }, // Intel Media driver
     { "i915",       4, "i965"   }, // Intel OTC GenX driver
     { "pvrsrvkm",   8, "pvr"    }, // Intel UMG PVR driver
     { "emgd",       4, "emgd"   }, // Intel ECG PVR driver


### PR DESCRIPTION
Add mapping of i915 kernel driver to Intel media driver
vaInitialize succeeds on systems with iHD driver without
having to export LIBVA_DRIVER_NAME=iHD

Fixes #244

Signed-off-by: Azhar Shaikh <azhar.shaikh@intel.com>