### PR TITLE
x11: Remove obsolete B16 & B32 tags in protocol struct definitions

### DIFF
--- a/va/x11/va_dri2str.h
+++ b/va/x11/va_dri2str.h
@@ -56,171 +56,171 @@
 #define X_DRI2SwapInterval      12
 
 typedef struct {
-    CARD32  attachment B32;
-    CARD32  name B32;
-    CARD32  pitch B32;
-    CARD32  cpp B32;
-    CARD32  flags B32;
+    CARD32  attachment;
+    CARD32  name;
+    CARD32  pitch;
+    CARD32  cpp;
+    CARD32  flags;
 } xDRI2Buffer;
 
 typedef struct {
     CARD8   reqType;
     CARD8   dri2ReqType;
-    CARD16  length B16;
-    CARD32  majorVersion B32;
-    CARD32  minorVersion B32;
+    CARD16  length;
+    CARD32  majorVersion;
+    CARD32  minorVersion;
 } xDRI2QueryVersionReq;
 #define sz_xDRI2QueryVersionReq   12
 
 typedef struct {
     BYTE    type;   /* X_Reply */
     BYTE    pad1;
-    CARD16  sequenceNumber B16;
-    CARD32  length B32;
-    CARD32  majorVersion B32;
-    CARD32  minorVersion B32;
-    CARD32  pad2 B32;
-    CARD32  pad3 B32;
-    CARD32  pad4 B32;
-    CARD32  pad5 B32;
+    CARD16  sequenceNumber;
+    CARD32  length;
+    CARD32  majorVersion;
+    CARD32  minorVersion;
+    CARD32  pad2;
+    CARD32  pad3;
+    CARD32  pad4;
+    CARD32  pad5;
 } xDRI2QueryVersionReply;
 #define sz_xDRI2QueryVersionReply   32
 
 typedef struct {
     CARD8   reqType;
     CARD8   dri2ReqType;
-    CARD16  length B16;
-    CARD32  window B32;
-    CARD32  driverType B32;
+    CARD16  length;
+    CARD32  window;
+    CARD32  driverType;
 } xDRI2ConnectReq;
 #define sz_xDRI2ConnectReq  12
 
 typedef struct {
     BYTE    type;   /* X_Reply */
     BYTE    pad1;
-    CARD16  sequenceNumber B16;
-    CARD32  length B32;
-    CARD32  driverNameLength B32;
-    CARD32  deviceNameLength B32;
-    CARD32  pad2 B32;
-    CARD32  pad3 B32;
-    CARD32  pad4 B32;
-    CARD32  pad5 B32;
+    CARD16  sequenceNumber;
+    CARD32  length;
+    CARD32  driverNameLength;
+    CARD32  deviceNameLength;
+    CARD32  pad2;
+    CARD32  pad3;
+    CARD32  pad4;
+    CARD32  pad5;
 } xDRI2ConnectReply;
 #define sz_xDRI2ConnectReply    32
 
 typedef struct {
     CARD8   reqType;
     CARD8   dri2ReqType;
-    CARD16  length B16;
-    CARD32  window B32;
-    CARD32  magic B32;
+    CARD16  length;
+    CARD32  window;
+    CARD32  magic;
 } xDRI2AuthenticateReq;
 #define sz_xDRI2AuthenticateReq   12
 
 typedef struct {
     BYTE    type;   /* X_Reply */
     BYTE    pad1;
-    CARD16  sequenceNumber B16;
-    CARD32  length B32;
-    CARD32  authenticated B32;
-    CARD32  pad2 B32;
-    CARD32  pad3 B32;
-    CARD32  pad4 B32;
-    CARD32  pad5 B32;
-    CARD32  pad6 B32;
+    CARD16  sequenceNumber;
+    CARD32  length;
+    CARD32  authenticated;
+    CARD32  pad2;
+    CARD32  pad3;
+    CARD32  pad4;
+    CARD32  pad5;
+    CARD32  pad6;
 } xDRI2AuthenticateReply;
 #define sz_xDRI2AuthenticateReply   32
 
 typedef struct {
     CARD8   reqType;
     CARD8   dri2ReqType;
-    CARD16  length B16;
-    CARD32  drawable B32;
+    CARD16  length;
+    CARD32  drawable;
 } xDRI2CreateDrawableReq;
 #define sz_xDRI2CreateDrawableReq   8
 
 typedef struct {
     CARD8   reqType;
     CARD8   dri2ReqType;
-    CARD16  length B16;
-    CARD32  drawable B32;
+    CARD16  length;
+    CARD32  drawable;
 } xDRI2DestroyDrawableReq;
 #define sz_xDRI2DestroyDrawableReq   8
 
 typedef struct {
     CARD8   reqType;
     CARD8   dri2ReqType;
-    CARD16  length B16;
-    CARD32  drawable B32;
-    CARD32  count B32;
+    CARD16  length;
+    CARD32  drawable;
+    CARD32  count;
 } xDRI2GetBuffersReq;
 #define sz_xDRI2GetBuffersReq   12
 
 typedef struct {
     BYTE    type;   /* X_Reply */
     BYTE    pad1;
-    CARD16  sequenceNumber B16;
-    CARD32  length B32;
-    CARD32  width B32;
-    CARD32  height B32;
-    CARD32  count B32;
-    CARD32  pad2 B32;
-    CARD32  pad3 B32;
-    CARD32  pad4 B32;
+    CARD16  sequenceNumber;
+    CARD32  length;
+    CARD32  width;
+    CARD32  height;
+    CARD32  count;
+    CARD32  pad2;
+    CARD32  pad3;
+    CARD32  pad4;
 } xDRI2GetBuffersReply;
 #define sz_xDRI2GetBuffersReply 32
 
 typedef struct {
     CARD8   reqType;
     CARD8   dri2ReqType;
-    CARD16  length B16;
-    CARD32  drawable B32;
-    CARD32  region B32;
-    CARD32  dest B32;
-    CARD32  src B32;
+    CARD16  length;
+    CARD32  drawable;
+    CARD32  region;
+    CARD32  dest;
+    CARD32  src;
 } xDRI2CopyRegionReq;
 #define sz_xDRI2CopyRegionReq   20
 
 typedef struct {
     BYTE    type;   /* X_Reply */
     BYTE    pad1;
-    CARD16  sequenceNumber B16;
-    CARD32  length B32;
-    CARD32  pad2 B32;
-    CARD32  pad3 B32;
-    CARD32  pad4 B32;
-    CARD32  pad5 B32;
-    CARD32  pad6 B32;
-    CARD32  pad7 B32;
+    CARD16  sequenceNumber;
+    CARD32  length;
+    CARD32  pad2;
+    CARD32  pad3;
+    CARD32  pad4;
+    CARD32  pad5;
+    CARD32  pad6;
+    CARD32  pad7;
 } xDRI2CopyRegionReply;
 #define sz_xDRI2CopyRegionReply 32
 
 typedef struct {
     CARD8   reqType;
     CARD8   dri2ReqType;
-    CARD16  length B16;
-    CARD32  drawable B32;
-    CARD32  target_msc_hi B32;
-    CARD32  target_msc_lo B32;
-    CARD32  divisor_hi B32;
-    CARD32  divisor_lo B32;
-    CARD32  remainder_hi B32;
-    CARD32  remainder_lo B32;
+    CARD16  length;
+    CARD32  drawable;
+    CARD32  target_msc_hi;
+    CARD32  target_msc_lo;
+    CARD32  divisor_hi;
+    CARD32  divisor_lo;
+    CARD32  remainder_hi;
+    CARD32  remainder_lo;
 } xDRI2SwapBuffersReq;
 #define sz_xDRI2SwapBuffersReq  32
 
 typedef struct {
     BYTE    type;   /* X_Reply */
     BYTE    pad1;
-    CARD16  sequenceNumber B16;
-    CARD32  length B32;
-    CARD32  swap_hi B32;
-    CARD32  swap_lo B32;
-    CARD32  pad2 B32;
-    CARD32  pad3 B32;
-    CARD32  pad4 B32;
-    CARD32  pad5 B32;
+    CARD16  sequenceNumber;
+    CARD32  length;
+    CARD32  swap_hi;
+    CARD32  swap_lo;
+    CARD32  pad2;
+    CARD32  pad3;
+    CARD32  pad4;
+    CARD32  pad5;
 } xDRI2SwapBuffersReply;
 #define sz_xDRI2SwapBuffersReply 32
 

--- a/va/x11/va_nvctrl.c
+++ b/va/x11/va_nvctrl.c
@@ -51,69 +51,69 @@
 typedef struct {
     CARD8 reqType;
     CARD8 nvReqType;
-    CARD16 length B16;
+    CARD16 length;
 } xnvCtrlQueryExtensionReq;
 #define sz_xnvCtrlQueryExtensionReq 4
 
 typedef struct {
     BYTE type;   /* X_Reply */
     CARD8 padb1;
-    CARD16 sequenceNumber B16;
-    CARD32 length B32;
-    CARD16 major B16;
-    CARD16 minor B16;
-    CARD32 padl4 B32;
-    CARD32 padl5 B32;
-    CARD32 padl6 B32;
-    CARD32 padl7 B32;
-    CARD32 padl8 B32;
+    CARD16 sequenceNumber;
+    CARD32 length;
+    CARD16 major;
+    CARD16 minor;
+    CARD32 padl4;
+    CARD32 padl5;
+    CARD32 padl6;
+    CARD32 padl7;
+    CARD32 padl8;
 } xnvCtrlQueryExtensionReply;
 #define sz_xnvCtrlQueryExtensionReply 32
 
 typedef struct {
     CARD8 reqType;
     CARD8 nvReqType;
-    CARD16 length B16;
-    CARD32 screen B32;
+    CARD16 length;
+    CARD32 screen;
 } xnvCtrlIsNvReq;
 #define sz_xnvCtrlIsNvReq 8
 
 typedef struct {
     BYTE type;   /* X_Reply */
     CARD8 padb1;
-    CARD16 sequenceNumber B16;
-    CARD32 length B32;
-    CARD32 isnv B32;
-    CARD32 padl4 B32;
-    CARD32 padl5 B32;
-    CARD32 padl6 B32;
-    CARD32 padl7 B32;
-    CARD32 padl8 B32;
+    CARD16 sequenceNumber;
+    CARD32 length;
+    CARD32 isnv;
+    CARD32 padl4;
+    CARD32 padl5;
+    CARD32 padl6;
+    CARD32 padl7;
+    CARD32 padl8;
 } xnvCtrlIsNvReply;
 #define sz_xnvCtrlIsNvReply 32
 
 typedef struct {
     CARD8 reqType;
     CARD8 nvReqType;
-    CARD16 length B16;
-    CARD16 target_id B16;    /* X screen number or GPU number */
-    CARD16 target_type B16;  /* X screen or GPU */
-    CARD32 display_mask B32;
-    CARD32 attribute B32;
+    CARD16 length;
+    CARD16 target_id;    /* X screen number or GPU number */
+    CARD16 target_type;  /* X screen or GPU */
+    CARD32 display_mask;
+    CARD32 attribute;
 } xnvCtrlQueryStringAttributeReq;
 #define sz_xnvCtrlQueryStringAttributeReq 16
 
 typedef struct {
     BYTE type;
     BYTE pad0;
-    CARD16 sequenceNumber B16;
-    CARD32 length B32;
-    CARD32 flags B32;
-    CARD32 n B32;    /* Length of string */
-    CARD32 pad4 B32;
-    CARD32 pad5 B32;
-    CARD32 pad6 B32;
-    CARD32 pad7 B32;
+    CARD16 sequenceNumber;
+    CARD32 length;
+    CARD32 flags;
+    CARD32 n;    /* Length of string */
+    CARD32 pad4;
+    CARD32 pad5;
+    CARD32 pad6;
+    CARD32 pad7;
 } xnvCtrlQueryStringAttributeReply;
 #define sz_xnvCtrlQueryStringAttributeReply 32
 


### PR DESCRIPTION
They were defined as empty strings on all platforms except for the
long unsupported Cray systems which needed to use bitfields to define
types smaller than 64-bits.

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>