### PR TITLE
Allow (and use by default) ORIGIN-relative driver paths

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,10 +157,14 @@ AC_ARG_ENABLE([va-messaging],
 AC_ARG_WITH(drivers-path,
     [AC_HELP_STRING([--with-drivers-path=[[path]]],
                     [drivers path])],
-    [], [with_drivers_path="$libdir/dri"])
+    [], [with_drivers_path="\$ORIGIN/dri"])
 
 LIBVA_DRIVERS_PATH="$with_drivers_path"
-AC_SUBST(LIBVA_DRIVERS_PATH)
+LIBVA_DRIVERS_PATH_ABSOLUTE="${with_drivers_path/\$ORIGIN/$libdir}"
+
+AC_DEFINE_UNQUOTED([VA_DRIVERS_PATH], ["$LIBVA_DRIVERS_PATH"], [Driver file path (potentially relative)])
+AC_SUBST(LIBVA_DRIVERS_PATH_ABSOLUTE)
+
 
 AC_DISABLE_STATIC
 AC_PROG_LIBTOOL
@@ -346,6 +350,7 @@ echo "libva - ${LIBVA_VERSION} (VA-API ${VA_API_VERSION})"
 echo
 echo Installation prefix .............. : $prefix
 echo Default driver path .............. : $LIBVA_DRIVERS_PATH
+echo Default driver install path ...... : $LIBVA_DRIVERS_PATH_ABSOLUTE
 echo Extra window systems ............. : $BACKENDS
 echo Build documentation .............. : $enable_docs
 echo Build with messaging ............. : $enable_va_messaging

--- a/meson.build
+++ b/meson.build
@@ -65,7 +65,7 @@ libva_lt_version = '@0@.@1@.@2@'.format(libva_lt_current,
 
 driverdir = get_option('driverdir')
 if driverdir == ''
-  driverdir = '@0@/@1@/@2@'.format(get_option('prefix'), get_option('libdir'), 'dri')
+  driverdir = '$ORIGIN/dri'
 endif
 
 configinc = include_directories('.')

--- a/pkgconfig/libva.pc.in
+++ b/pkgconfig/libva.pc.in
@@ -2,7 +2,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
-driverdir=@LIBVA_DRIVERS_PATH@
+driverdir=@LIBVA_DRIVERS_PATH_ABSOLUTE@
 libva_version=@LIBVA_VERSION@
 
 Name: libva

--- a/pkgconfig/meson.build
+++ b/pkgconfig/meson.build
@@ -6,7 +6,7 @@ pkgconf.set('libdir', '${prefix}/@0@'.format(get_option('libdir')))
 pkgconf.set('includedir', '${prefix}/@0@'.format(get_option('includedir')))
 pkgconf.set('LIBVA_VERSION', libva_version)
 pkgconf.set('VA_API_VERSION', va_api_version)
-pkgconf.set('LIBVA_DRIVERS_PATH', driverdir)
+pkgconf.set('LIBVA_DRIVERS_PATH_ABSOLUTE', '@0@/@1@'.format(get_option('prefix'), get_option('libdir')).join(driverdir.split('$ORIGIN')))
 
 pkg_install_dir = '@0@/pkgconfig'.format(get_option('libdir'))
 

--- a/va/Makefile.am
+++ b/va/Makefile.am
@@ -23,8 +23,7 @@
 SUBDIRS =
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) \
-	-DVA_DRIVERS_PATH="\"$(LIBVA_DRIVERS_PATH)\""
+	-I$(top_srcdir)
 
 LDADD = \
 	$(LIBVA_LT_LDFLAGS)


### PR DESCRIPTION
This behaves similarly to the `$ORIGIN` feature in the `RPATH` and `RUNPATH` ELF headers. It allows libva and the driver modules to be directory-portable (without having to set the env var at runtime), since libva only needs the path to the library dir relative to its own install dir, rather than an absolute path.

This retains compatibility with existing drivers' build systems by setting the pkgconfig driverdir value, as with the existing code.

As far as I can tell, `dladdr` is available on all targeted systems.

I was initially concerned that using `dladdr` this way might cause problems for static linking, but that's not supported in libva anyway.