### PR TITLE
build: meson: enables va messaging and visibility

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -108,6 +108,15 @@ if get_option('with_wayland') != 'no'
   WITH_WAYLAND = wayland_dep.found()
 endif
 
+va_c_args = []
+if get_option('enable_va_messaging')
+  va_c_args += ['-DENABLE_VA_MESSAGING=1']
+endif
+
+# Symbol visibility
+if cc.has_argument('-fvisibility=hidden')
+  va_c_args += ['-DHAVE_GNUC_VISIBILITY_ATTRIBUTE']
+endif
 
 if (not WITH_DRM and not WITH_X11 and not WITH_WAYLAND)
   error('Please install at least one backend dev files (DRM, X11, Wayland)')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,4 @@ option('with_x11', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'aut
 option('with_glx', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'auto')
 option('with_wayland', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'auto')
 option('enable_docs', type : 'boolean', value : false)
+option('enable_va_messaging', type : 'boolean', value : true)

--- a/va/meson.build
+++ b/va/meson.build
@@ -62,7 +62,7 @@ libva = shared_library(
             libva_headers_priv,
   soversion : libva_lt_current,
   version : libva_lt_version,
-  c_args : '-DVA_DRIVERS_PATH="' + driverdir + '"',
+  c_args : ['-DVA_DRIVERS_PATH="' + driverdir + '"'] + va_c_args,
   include_directories : configinc,
   link_args : '-Wl,-version-script,' + libva_sym_path,
   link_depends : libva_sym,


### PR DESCRIPTION
This patch syncs with the defined compiler flags in autotools: the
enable of VA messaging and the compiler's support to visibility
attribute.

Fixes: #275