### PR TITLE
drm: unbreak VA_DRM_IsRenderNodeFd on FreeBSD

### DIFF
--- a/va/drm/va_drm_utils.c
+++ b/va/drm/va_drm_utils.c
@@ -26,7 +26,6 @@
 
 #include "sysdeps.h"
 #include <xf86drm.h>
-#include <sys/stat.h>
 #include "va_drm_utils.h"
 #include "va_drmcommon.h"
 
@@ -87,12 +86,11 @@ VA_DRM_GetDriverName(VADriverContextP ctx, char **driver_name_ptr)
 int
 VA_DRM_IsRenderNodeFd(int fd)
 {
-    struct stat st;
     const char *name;
 
     /* Check by device node */
-    if (fstat(fd, &st) == 0)
-        return S_ISCHR(st.st_mode) && (st.st_rdev & 0x80);
+    if (drmGetNodeTypeFromFd(fd) == DRM_NODE_RENDER)
+        return 1;
 
     /* Check by device name */
     name = drmGetDeviceNameFromFd2(fd);

--- a/va/drm/va_drm_utils.c
+++ b/va/drm/va_drm_utils.c
@@ -95,7 +95,7 @@ VA_DRM_IsRenderNodeFd(int fd)
         return S_ISCHR(st.st_mode) && (st.st_rdev & 0x80);
 
     /* Check by device name */
-    name = drmGetDeviceNameFromFd(fd);
+    name = drmGetDeviceNameFromFd2(fd);
     if (name)
         return strncmp(name, "/dev/dri/renderD", 16) == 0;
 


### PR DESCRIPTION
`drmGetDeviceNameFromFd` doesn't support render nodes according to [libdrm@37d790f](https://gitlab.freedesktop.org/mesa/drm/commit/37d790f7d449). And `st_rdev & 0x80` may not work on FreeBSD because major/minor semantics are different.
