### PR TITLE
Unbreak on GCC < 5.0

### DIFF
--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -3271,6 +3271,7 @@ static void va_TraceVAEncMiscParameterBuffer(
     }
     case VAEncMiscParameterTypeROI:
     {
+        int i;
         VAEncMiscParameterBufferROI *p = (VAEncMiscParameterBufferROI *)tmp->data;
 
         va_TraceMsg(trace_ctx, "\t--VAEncMiscParameterBufferROI\n");
@@ -3278,7 +3279,7 @@ static void va_TraceVAEncMiscParameterBuffer(
         va_TraceMsg(trace_ctx, "\tmax_delta_qp = %d\n", p->max_delta_qp);
         va_TraceMsg(trace_ctx, "\tmin_delta_qp = %d\n", p->min_delta_qp);
         va_TraceMsg(trace_ctx, "\troi_flags.bits.roi_value_is_qp_delta = %d\n", p->roi_flags.bits.roi_value_is_qp_delta);
-        for (int i = 0; i < p->num_roi; i++) {
+        for (i = 0; i < p->num_roi; i++) {
             va_TraceMsg(trace_ctx, "\troi[%d].roi_rectangle.x      = %d\n", i, p->roi[i].roi_rectangle.x);
             va_TraceMsg(trace_ctx, "\troi[%d].roi_rectangle.y      = %d\n", i, p->roi[i].roi_rectangle.y);
             va_TraceMsg(trace_ctx, "\troi[%d].roi_rectangle.width  = %d\n", i, p->roi[i].roi_rectangle.width);


### PR DESCRIPTION
Regressed by #269. Neither meson.build no configure.ac define `-std=`,so GCC < 5.0 would implicitly use `gnu89` e.g.,
http://pylon.nyi.freebsd.org/data/head-powerpc64-default/p498440_s346039/logs/errors/libva-2.4.1.log