### PR TITLE
Remove unnecessary linux/videodev2.h include

### DIFF
--- a/va/va_backend.h
+++ b/va/va_backend.h
@@ -30,7 +30,6 @@
 #define _VA_BACKEND_H_
 
 #include <va/va.h>
-#include <linux/videodev2.h>
 
 typedef struct VADriverContext *VADriverContextP;
 typedef struct VADisplayContext *VADisplayContextP;

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -51,7 +51,7 @@
 #include <sys/syscall.h>
 #include <pthread.h>
 #include <unistd.h>
-#include <time.h>
+#include <sys/time.h>
 #include <errno.h>
 
 /*


### PR DESCRIPTION
Nothing in this header is actually used for anything, and this simplifies building for FreeBSD.