### PR TITLE
Extend parameter buffers to support Hantro G1 H.264

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,7 +20,7 @@ project(
 # - reset minor version to zero when major version is incremented
 va_api_major_version = 1
 va_api_minor_version = 6
-va_api_micro_version = 0
+va_api_micro_version = 1
 
 va_api_version = '@0@.@1@.@2@'.format(va_api_major_version,
 				      va_api_minor_version,

--- a/va/va.h
+++ b/va/va.h
@@ -3149,9 +3149,11 @@ typedef struct _VASliceParameterBufferH264
     uint8_t chroma_weight_l1_flag;
     int16_t chroma_weight_l1[32][2];
     int16_t chroma_offset_l1[32][2];
+    /** \brief Size in bits of the dec_ref_pic_marking() syntax element. */
+    uint32_t dec_ref_pic_marking_bit_size;
 
     /** \brief Reserved bytes for future use, must be zero */
-    uint32_t                va_reserved[VA_PADDING_LOW];
+    uint32_t                va_reserved[3];
 } VASliceParameterBufferH264;
 
 /****************************

--- a/va/va.h
+++ b/va/va.h
@@ -3133,6 +3133,8 @@ typedef struct _VASliceParameterBufferH264
     uint8_t disable_deblocking_filter_idc;
     int8_t slice_alpha_c0_offset_div2;
     int8_t slice_beta_offset_div2;
+    /** \brief Same as the H.264 bitstream syntax element. */
+    uint16_t  idr_pic_id;
     VAPictureH264 RefPicList0[32];	/* See 8.2.4.2 */
     VAPictureH264 RefPicList1[32];	/* See 8.2.4.2 */
     uint8_t luma_log2_weight_denom;

--- a/va/va.h
+++ b/va/va.h
@@ -3076,6 +3076,10 @@ typedef struct _VAPictureParameterBufferH264
         uint32_t value;
     } pic_fields;
     uint16_t frame_num;
+    /** \brief Same as the H.264 bitstream syntax element. */
+    uint8_t num_ref_idx_l0_default_active_minus1;
+    /** \brief Same as the H.264 bitstream syntax element. */
+    uint8_t num_ref_idx_l1_default_active_minus1;
 
     /** \brief Reserved bytes for future use, must be zero */
     uint32_t                va_reserved[VA_PADDING_MEDIUM];

--- a/va/va.h
+++ b/va/va.h
@@ -3153,9 +3153,16 @@ typedef struct _VASliceParameterBufferH264
     int16_t chroma_offset_l1[32][2];
     /** \brief Size in bits of the dec_ref_pic_marking() syntax element. */
     uint32_t dec_ref_pic_marking_bit_size;
+    /**
+     * \brief Size in bits of the pic_order_cnt related syntax elements.
+     *
+     * Size in bits of the pic_order_cnt_lsb, delta_pic_order_cnt_bottom,
+     * delta_pic_order_cnt[0], and delta_pic_order_cnt[1] syntax elements.
+     */
+    uint32_t pic_order_cnt_bit_size;
 
     /** \brief Reserved bytes for future use, must be zero */
-    uint32_t                va_reserved[3];
+    uint32_t                va_reserved[2];
 } VASliceParameterBufferH264;
 
 /****************************


### PR DESCRIPTION
The Hantro G1 hardware H.264 decoder parses slices itself, with some assistance.
It requires the parsed `num_ref_idx_l[01]_default_active_minus1` and `idr_pic_id` syntax elements, as well as the size in bits of the `dec_ref_pic_marking()` syntax element and the total size in bits of the `pic_order_cnt_lsb`/`delta_pic_order_cnt_bottom`/`delta_pic_order_cnt[0]`/`delta_pic_order_cnt[1]` syntax elements.

These patches extend `VAPictureParameterBufferH264` and `VASliceParameterBufferH264` to allow supporting Hantro G1 decoders via [libva-v4l2-request](https://github.com/bootlin/libva-v4l2-request).