### PR TITLE
configure: use correct comparison operator

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -259,7 +259,7 @@ if test "$USE_X11:$enable_glx" = "no:yes"; then
    AC_MSG_ERROR([VA/GLX explicitly enabled, but VA/X11 isn't built])
 fi
 
-if test "$USE_X11" == "yes" -a "$enable_glx" != "no"; then
+if test "$USE_X11" = "yes" -a "$enable_glx" != "no"; then
     PKG_CHECK_MODULES([GLX], [gl x11], [USE_GLX="yes"], [:])
     saved_CPPFLAGS="$CPPFLAGS"
     saved_LIBS="$LIBS"


### PR DESCRIPTION
'==' is invalid posix shell syntax. With dash as /bin/sh
the check fails with:

./configure: 17656: test: yes: unexpected operator

Signed-off-by: Michael Olbrich <m.olbrich@pengutronix.de>