### PR TITLE
ensure that all meson files are part of the release tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,7 +30,7 @@ if ENABLE_DOCS
 SUBDIRS += doc
 endif
 
-EXTRA_DIST=doc/va_footer.html
+EXTRA_DIST=doc/va_footer.html meson.build meson_options.txt
 # Extra clean files so that maintainer-clean removes *everything*
 MAINTAINERCLEANFILES = \
 	aclocal.m4 compile config.guess config.sub \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -25,6 +25,7 @@ install-data-local: install-html
 
 EXTRA_DIST = \
 	Doxyfile.in			\
+	meson.build			\
 	$(NULL)
 
 VA_HEADER_DIR   = $(top_srcdir)/va

--- a/pkgconfig/Makefile.am
+++ b/pkgconfig/Makefile.am
@@ -43,7 +43,7 @@ all_pcfiles_in	+= libva-wayland.pc.in
 pkgconfigdir = @pkgconfigdir@
 pkgconfig_DATA = $(pcfiles)
 
-EXTRA_DIST = $(all_pcfiles_in)
+EXTRA_DIST = $(all_pcfiles_in) meson.build
 
 DISTCLEANFILES = $(pcfiles)
 

--- a/va/Makefile.am
+++ b/va/Makefile.am
@@ -147,4 +147,5 @@ DISTCLEANFILES = \
 EXTRA_DIST = \
 	libva.syms		\
 	va_version.h.in		\
+	meson.build		\
 	$(NULL)


### PR DESCRIPTION
They are currently missing, so meson can only be used when building from git.