### PR TITLE
drm: Add mapping of hantro kernel driver

### DIFF
--- a/va/drm/va_drm_utils.c
+++ b/va/drm/va_drm_utils.c
@@ -44,6 +44,7 @@ static const struct driver_name_map g_driver_name_map[] = {
     { "nouveau",    7, "nouveau"  }, // Mesa Gallium driver
     { "radeon",     6, "r600"     }, // Mesa Gallium driver
     { "amdgpu",     6, "radeonsi" }, // Mesa Gallium driver
+    { "hantro",     6, "hantro"   }, // Hantro Media driver
     { NULL,         0, NULL }
 };
 


### PR DESCRIPTION
This patch allows hantro kernel driver to be recognized
by va_getDriverName and for vaInitialize to select the
correct VA-API driver for hantro.

Signed-off-by: Murugasen Krishnan, Kuhanh <kuhanh.murugasen.krishnan@intel.com>