### PR TITLE
Pass offset and size of pred_weight_table

### DIFF
--- a/va/va_enc_hevc.h
+++ b/va/va_enc_hevc.h
@@ -665,8 +665,15 @@ typedef struct _VAEncSliceParameterBufferHEVC {
         uint32_t        value;
     } slice_fields;
 
+
+    /** \brief bit offset of syntax element pred_weight_table() in slice segment header.
+     * It aligns with the starting position of the current packed slice header.
+     */
+    uint32_t                pred_weight_table_bit_offset;
+    /** \brief bit length of syntax element pred_weight_table() in slice segment header. */
+    uint32_t                pred_weight_table_bit_length;
     /** \brief Reserved bytes for future use, must be zero */
-    uint32_t                va_reserved[VA_PADDING_MEDIUM];
+    uint32_t                va_reserved[VA_PADDING_MEDIUM-2];
     /**@}*/
 } VAEncSliceParameterBufferHEVC;
 


### PR DESCRIPTION
These two parameters are gotten from packed slice header, are used
to write back pred_weight_tabe into packed slice header
of the final bit stream.