### PR TITLE
add multiple backend driver support 

### DIFF
--- a/va/android/va_android.cpp
+++ b/va/android/va_android.cpp
@@ -100,9 +100,10 @@ static void va_DisplayContextDestroy (
     free(pDisplayContext);
 }
 
-static VAStatus va_DisplayContextGetDriverName (
+}
+static VAStatus va_DisplayContextGetNumCandidates(
     VADisplayContextP pDisplayContext,
-    char **driver_name
+    int *num_candidates
 )
 {
     VADriverContextP const ctx = pDisplayContext->pDriverContext;
@@ -116,8 +117,18 @@ static VAStatus va_DisplayContextGetDriverName (
         return VA_STATUS_ERROR_UNKNOWN;
     }
     drm_state->auth_type = VA_DRM_AUTH_CUSTOM;
+    return VA_DRM_GetNumCandidates(ctx, num_candidates);
+}
 
-    return VA_DRM_GetDriverName(ctx, driver_name);
+static VAStatus va_DisplayContextGetDriverNameByIndex (
+    VADisplayContextP pDisplayContext,
+    char **driver_name,
+    int candidate_index
+)
+{
+    VADriverContextP const ctx = pDisplayContext->pDriverContext;
+
+    return VA_DRM_GetDriverName(ctx, driver_name, candidate_index);
 }
 
 
@@ -138,7 +149,8 @@ VADisplay vaGetDisplay (
 
     pDisplayContext->vaIsValid       = va_DisplayContextIsValid;
     pDisplayContext->vaDestroy       = va_DisplayContextDestroy;
-    pDisplayContext->vaGetDriverName = va_DisplayContextGetDriverName;
+    pDisplayContext->vaGetDriverNameByIndex = va_DisplayContextGetDriverNameByIndex;
+    pDisplayContext->vaGetNumCandidates = va_DisplayContextGetNumCandidates;
 
     pDriverContext = va_newDriverContext(pDisplayContext);
     if (!pDriverContext) {

--- a/va/drm/va_drm_utils.c
+++ b/va/drm/va_drm_utils.c
@@ -48,14 +48,39 @@ static const struct driver_name_map g_driver_name_map[] = {
     { NULL,         0, NULL }
 };
 
+/* Returns the VA driver candidate num for the active display*/
+VAStatus
+VA_DRM_GetNumCandidates(VADriverContextP ctx, int * num_candidates)
+{
+    struct drm_state * const drm_state = ctx->drm_state;
+    drmVersionPtr drm_version;
+    int num_of_candidate = 0;
+    const struct driver_name_map *m = NULL;
+    if (!drm_state || drm_state->fd < 0)
+        return VA_STATUS_ERROR_INVALID_DISPLAY;
+    drm_version = drmGetVersion(drm_state->fd);
+    if (!drm_version)
+        return VA_STATUS_ERROR_UNKNOWN;
+    for (m = g_driver_name_map; m->key != NULL; m++) {
+        if (drm_version->name_len >= m->key_len &&
+            strncmp(drm_version->name, m->key, m->key_len) == 0) {
+            num_of_candidate ++;
+        }
+    }
+    drmFreeVersion(drm_version);
+    *num_candidates = num_of_candidate;
+    return VA_STATUS_SUCCESS;
+}
+
 /* Returns the VA driver name for the active display */
 VAStatus
-VA_DRM_GetDriverName(VADriverContextP ctx, char **driver_name_ptr)
+VA_DRM_GetDriverName(VADriverContextP ctx, char **driver_name_ptr, int candidate_index)
 {
     struct drm_state * const drm_state = ctx->drm_state;
     drmVersionPtr drm_version;
     char *driver_name = NULL;
     const struct driver_name_map *m;
+    int current_index = 0;
 
     *driver_name_ptr = NULL;
 
@@ -68,8 +93,12 @@ VA_DRM_GetDriverName(VADriverContextP ctx, char **driver_name_ptr)
 
     for (m = g_driver_name_map; m->key != NULL; m++) {
         if (drm_version->name_len >= m->key_len &&
-            strncmp(drm_version->name, m->key, m->key_len) == 0)
-            break;
+            strncmp(drm_version->name, m->key, m->key_len) == 0) {
+            if (current_index == candidate_index) {
+                break;
+            }
+            current_index ++;
+        }
     }
     drmFreeVersion(drm_version);
 

--- a/va/drm/va_drm_utils.h
+++ b/va/drm/va_drm_utils.h
@@ -41,7 +41,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
+DLL_HIDDEN
+VAStatus
+VA_DRM_GetNumCandidates(VADriverContextP ctx, int * num_candidates);
 /**
  * \brief Returns the VA driver name for the active display.
  *
@@ -62,7 +64,7 @@ extern "C" {
  */
 DLL_HIDDEN
 VAStatus
-VA_DRM_GetDriverName(VADriverContextP ctx, char **driver_name_ptr);
+VA_DRM_GetDriverName(VADriverContextP ctx, char **driver_name_ptr, int candidate_index);
 
 /**
  * \brief Checks whether the file descriptor is a DRM Render-Nodes one

--- a/va/va_backend.h
+++ b/va/va_backend.h
@@ -651,9 +651,19 @@ struct VADisplayContext
     void *error_callback_user_context;
     VAMessageCallback info_callback;
     void *info_callback_user_context;
+    VAStatus (*vaGetNumCandidates) (
+        VADisplayContextP ctx,
+        int * num_candidates
+    );
+
+    VAStatus (*vaGetDriverNameByIndex) (
+        VADisplayContextP ctx,
+        char **driver_name,
+        int  candidate_index
+    );
 
     /** \brief Reserved bytes for future use, must be zero */
-    unsigned long reserved[32];
+    unsigned long reserved[30];
 };
 
 typedef VAStatus (*VADriverInit) (

--- a/va/wayland/va_wayland_drm.c
+++ b/va/wayland/va_wayland_drm.c
@@ -117,6 +117,29 @@ static const struct wl_drm_listener drm_listener = {
 };
 
 static VAStatus
+va_DisplayContextGetNumCandidates(
+    VADisplayContextP pDisplayContext,
+    int *candidate_index
+)
+{
+    VADriverContextP const ctx = pDisplayContext->pDriverContext;
+
+    return VA_DRM_GetNumCandidates(ctx, candidate_index);
+}
+
+static VAStatus
+va_DisplayContextGetDriverNameByIndex(
+    VADisplayContextP pDisplayContext,
+    char            **driver_name_ptr,
+    int             candidate_index
+)
+{
+    VADriverContextP const ctx = pDisplayContext->pDriverContext;
+
+    return VA_DRM_GetDriverName(ctx, driver_name_ptr, candidate_index);
+}
+
+static VAStatus
 va_DisplayContextGetDriverName(
     VADisplayContextP pDisplayContext,
     char            **driver_name_ptr
@@ -124,7 +147,7 @@ va_DisplayContextGetDriverName(
 {
     VADriverContextP const ctx = pDisplayContext->pDriverContext;
 
-    return VA_DRM_GetDriverName(ctx, driver_name_ptr);
+    return VA_DRM_GetDriverName(ctx, driver_name_ptr, 0);
 }
 
 void
@@ -237,6 +260,8 @@ va_wayland_drm_create(VADisplayContextP pDisplayContext)
     wl_drm_ctx->is_authenticated        = 0;
     pDisplayContext->opaque             = wl_drm_ctx;
     pDisplayContext->vaGetDriverName    = va_DisplayContextGetDriverName;
+    pDisplayContext->vaGetNumCandidates  = va_DisplayContextGetNumCandidates;
+    pDisplayContext->vaGetDriverNameByIndex = va_DisplayContextGetDriverNameByIndex;
 
     drm_state = calloc(1, sizeof(struct drm_state));
     if (!drm_state) {


### PR DESCRIPTION
enable multiple driver support, if there are no vaSetDriverName is called or environment variable LIBVA_DRIVER_NAME is set.  driver will select driver from g_driver_name_map, if there are i965 and iHD. 
libva will try to load iHD firstly, if it failed. then it will load i965.