### PR TITLE
libva 2.7.0 pre1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@
 # - reset micro version to zero when minor version is incremented
 # - reset minor version to zero when major version is incremented
 m4_define([va_api_major_version], [1])
-m4_define([va_api_minor_version], [6])
+m4_define([va_api_minor_version], [7])
 m4_define([va_api_micro_version], [0])
 
 m4_define([va_api_version],

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 # - reset micro version to zero when VA-API major or minor version is changed
 project(
   'libva', 'c',
-  version : '2.6.0.1',
+  version : '2.7.0.1',
   meson_version : '>= 0.37.0',
   default_options : [ 'warning_level=1',
                       'buildtype=debugoptimized' ])
@@ -19,7 +19,7 @@ project(
 # - reset micro version to zero when minor version is incremented
 # - reset minor version to zero when major version is incremented
 va_api_major_version = 1
-va_api_minor_version = 6
+va_api_minor_version = 7
 va_api_micro_version = 0
 
 va_api_version = '@0@.@1@.@2@'.format(va_api_major_version,

--- a/va/va.c
+++ b/va/va.c
@@ -470,6 +470,7 @@ static VAStatus va_openDriver(VADisplay dpy, char *driver_name)
                 int minor;
             } compatible_versions[] = {
                 { VA_MAJOR_VERSION, VA_MINOR_VERSION },
+                { VA_MAJOR_VERSION, 6 },
                 { VA_MAJOR_VERSION, 5 },
                 { VA_MAJOR_VERSION, 4 },
                 { VA_MAJOR_VERSION, 3 },


### PR DESCRIPTION
Bump VA-API version to 1.7.0 pre1 and libva to 2.7.0 pre1

Signed-off-by: Carl Zhang <carl.zhang@intel.com>