### PR TITLE
Add config attribute to advertise HEVC encoder features

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -371,6 +371,30 @@ typedef int VAStatus;	/** Return status type from functions */
 #define VA_EXEC_MODE_POWER_SAVING 0x1
 #define VA_EXEC_MODE_PERFORMANCE  0x2
 
+/* Values used to describe device features. */
+/** The feature is not supported by the device.
+ *
+ * Any corresponding feature flag must not be set.
+ */
+#define VA_FEATURE_NOT_SUPPORTED  0
+/** The feature is supported by the device.
+ *
+ * The user may decide whether or not to use this feature.
+ *
+ * Note that support for a feature only indicates that the hardware
+ * is able to use it; whether it is actually a positive change to
+ * enable it in a given situation will depend on other factors
+ * including the input provided by the user.
+ */
+#define VA_FEATURE_SUPPORTED      1
+/** The feature is required by the device.
+ *
+ * The device does not support not enabling this feature, so any
+ * corresponding feature flag must be set and any additional
+ * configuration needed by the feature must be supplied.
+ */
+#define VA_FEATURE_REQUIRED       2
+
 /**
  * Returns a short english description of error_status
  */
@@ -956,6 +980,26 @@ typedef enum
      */
     VAConfigAttribProtectedContentUsage = 49,
 
+    /** \brief HEVC/H.265 encoding features.  Read-only.
+     *
+     * This attribute describes the supported features of an
+     * HEVC/H.265 encoder configuration.  The value returned uses the
+     * VAConfigAttribValEncHEVCFeatures type.
+     *
+     * If this attribute is supported by a driver then it must also
+     * support the VAConfigAttribEncHEVCBlockSizes attribute.
+     */
+    VAConfigAttribEncHEVCFeatures       = 50,
+    /** \brief HEVC/H.265 encoding block sizes.  Read-only.
+     *
+     * This attribute describes the supported coding tree and transform
+     * block sizes of an HEVC/H.265 encoder configuration.  The value
+     * returned uses the VAConfigAttribValEncHEVCBlockSizes type.
+     *
+     * If this attribute is supported by a driver then it must also
+     * support the VAConfigAttribEncHEVCFeatures attribute.
+     */
+    VAConfigAttribEncHEVCBlockSizes     = 51,
     /**@}*/
     VAConfigAttribTypeMax
 } VAConfigAttribType;

--- a/va/va_enc_hevc.h
+++ b/va/va_enc_hevc.h
@@ -45,6 +45,193 @@ extern "C" {
  * @{
  */
 
+/** Attribute value for VAConfigAttribEncHEVCFeatures.
+ *
+ * This attribute decribes the supported features of an HEVC/H.265
+ * encoder configuration.
+ *
+ * All of the field values in this attribute are VA_FEATURE_* values,
+ * indicating support for the corresponding feature.
+ */
+typedef union VAConfigAttribValEncHEVCFeatures {
+    struct {
+        /** Separate colour planes.
+         *
+         * Allows setting separate_colour_plane_flag in the SPS.
+         */
+        uint32_t separate_colour_planes     : 2;
+        /** Scaling lists.
+         *
+         * Allows scaling_list() elements to be present in both the SPS
+         * and the PPS.  The decoded form of the scaling lists must also
+         * be supplied in a VAQMatrixBufferHEVC buffer when scaling lists
+         * are enabled.
+         */
+        uint32_t scaling_lists              : 2;
+        /** Asymmetric motion partitions.
+         *
+         * Allows setting amp_enabled_flag in the SPS.
+         */
+        uint32_t amp                        : 2;
+        /** Sample adaptive offset filter.
+         *
+         * Allows setting slice_sao_luma_flag and slice_sao_chroma_flag
+         * in slice headers.
+         */
+        uint32_t sao                        : 2;
+        /** PCM sample blocks.
+         *
+         * Allows setting pcm_enabled_flag in the SPS.  When enabled
+         * PCM parameters must be supplied with the sequence parameters,
+         * including block sizes which may be further constrained as
+         * noted in the VAConfigAttribEncHEVCBlockSizes attribute.
+         */
+        uint32_t pcm                        : 2;
+        /** Temporal motion vector Prediction.
+         *
+         * Allows setting slice_temporal_mvp_enabled_flag in slice
+         * headers.
+         */
+        uint32_t temporal_mvp               : 2;
+        /** Strong intra smoothing.
+         *
+         * Allows setting strong_intra_smoothing_enabled_flag in the SPS.
+         */
+        uint32_t strong_intra_smoothing     : 2;
+        /** Dependent slices.
+         *
+         * Allows setting dependent_slice_segment_flag in slice headers.
+         */
+        uint32_t dependent_slices           : 2;
+        /** Sign data hiding.
+         *
+         * Allows setting sign_data_hiding_enable_flag in the PPS.
+         */
+        uint32_t sign_data_hiding           : 2;
+        /** Constrained intra prediction.
+         *
+         * Allows setting constrained_intra_pred_flag in the PPS.
+         */
+        uint32_t constrained_intra_pred     : 2;
+        /** Transform skipping.
+         *
+         * Allows setting transform_skip_enabled_flag in the PPS.
+         */
+        uint32_t transform_skip             : 2;
+        /** QP delta within coding units.
+         *
+         * Allows setting cu_qp_delta_enabled_flag in the PPS.  When
+         * enabled, diff_cu_qp_delta_depth must be set to zero.
+         */
+        uint32_t cu_qp_delta                : 2;
+        /** Weighted prediction.
+         *
+         * Allows setting weighted_pred_flag and weighted_bipred_flag in
+         * the PPS.  The pred_weight_table() data must be supplied with
+         * every slice header when weighted prediction is enabled.
+         */
+        uint32_t weighted_prediction        : 2;
+        /** Transform and quantisation bypass.
+         *
+         * Allows setting transquant_bypass_enabled_flag in the PPS.
+         */
+        uint32_t transquant_bypass          : 2;
+        /** Deblocking filter disable.
+         *
+         * Allows setting slice_deblocking_filter_disabled_flag.
+         */
+        uint32_t deblocking_filter_disable  : 2;
+        /* Reserved for future use. */
+        uint32_t reserved                   : 2;
+    } bits;
+    uint32_t value;
+} VAConfigAttribValEncHEVCFeatures;
+
+/** Attribute value for VAConfigAttribEncHEVCBlockSizes.
+ *
+ * This attribute describes the supported coding tree and transform block
+ * sizes of an HEVC/H.265 encoder configuration
+ */
+typedef union VAConfigAttribValEncHEVCBlockSizes {
+    struct {
+        /** Largest supported size of coding tree blocks.
+         *
+         * CtbLog2SizeY must not be larger than this.
+         */
+        uint32_t log2_max_coding_tree_block_size_minus3    : 2;
+        /** Smallest supported size of coding tree blocks.
+         *
+         * CtbLog2SizeY must not be smaller than this.
+         *
+         * This may be the same as the maximum size, indicating that only
+         * one CTB size is supported.
+         */
+        uint32_t log2_min_coding_tree_block_size_minus3    : 2;
+
+        /** Smallest supported size of luma coding blocks.
+         *
+         * MinCbLog2SizeY must not be smaller than this.
+         */
+        uint32_t log2_min_luma_coding_block_size_minus3    : 2;
+
+        /** Largest supported size of luma transform blocks.
+         *
+         * MaxTbLog2SizeY must not be larger than this.
+         */
+        uint32_t log2_max_luma_transform_block_size_minus2 : 2;
+        /** Smallest supported size of luma transform blocks.
+         *
+         * MinTbLog2SizeY must not be smaller than this.
+         */
+        uint32_t log2_min_luma_transform_block_size_minus2 : 2;
+
+        /** Largest supported transform hierarchy depth in inter
+         *  coding units.
+         *
+         * max_transform_hierarchy_depth_inter must not be larger
+         * than this.
+         */
+        uint32_t max_max_transform_hierarchy_depth_inter   : 2;
+        /** Smallest supported transform hierarchy depth in inter
+         *  coding units.
+         *
+         * max_transform_hierarchy_depth_inter must not be smaller
+         * than this.
+         */
+        uint32_t min_max_transform_hierarchy_depth_inter   : 2;
+
+        /** Largest supported transform hierarchy depth in intra
+         *  coding units.
+         *
+         * max_transform_hierarchy_depth_intra must not be larger
+         * than this.
+         */
+        uint32_t max_max_transform_hierarchy_depth_intra   : 2;
+        /** Smallest supported transform hierarchy depth in intra
+         *  coding units.
+         *
+         * max_transform_hierarchy_depth_intra must not be smaller
+         * than this.
+         */
+        uint32_t min_max_transform_hierarchy_depth_intra   : 2;
+
+        /** Largest supported size of PCM coding blocks.
+         *
+         *  Log2MaxIpcmCbSizeY must not be larger than this.
+         */
+        uint32_t log2_max_pcm_coding_block_size_minus3     : 2;
+        /** Smallest supported size of PCM coding blocks.
+         *
+         *  Log2MinIpcmCbSizeY must not be smaller than this.
+         */
+        uint32_t log2_min_pcm_coding_block_size_minus3     : 2;
+
+        /** Reserved for future use. */
+        uint32_t reserved                                  : 10;
+    } bits;
+    uint32_t value;
+} VAConfigAttribValEncHEVCBlockSizes;
+
 /**
  * @name Picture flags
  *

--- a/va/va_str.c
+++ b/va/va_str.c
@@ -141,6 +141,8 @@ const char *vaConfigAttribTypeStr(VAConfigAttribType configAttribType)
     TOSTR(VAConfigAttribProtectedContentCipherMode);
     TOSTR(VAConfigAttribProtectedContentCipherSampleType);
     TOSTR(VAConfigAttribProtectedContentUsage);
+    TOSTR(VAConfigAttribEncHEVCFeatures);
+    TOSTR(VAConfigAttribEncHEVCBlockSizes);
     case VAConfigAttribTypeMax: break;
     }
     return "<unknown config attribute type>";


### PR DESCRIPTION
I see there is an incomplete version of pretty much the same thing already at https://github.com/intel/libva/pull/379 .  To compare with the most obvious change between them, I don't think there is any point in trying to make the config attribute look codec-generic because they have to be different for each codec anyway (like the existing JPEG one) and we aren't going to run out of index values any time soon.  There will likely need to be further attributes for HEVC RExt and SCC if they are added, since the additional flags there will not fit in the current attribute.