### PR TITLE
Fix HDR10 MaxCLL and MaxFALL documentation

### DIFF
--- a/va/va_vpp.h
+++ b/va/va_vpp.h
@@ -805,15 +805,15 @@ typedef struct _VAHdrMetaDataHDR10
      */
     uint32_t    min_display_mastering_luminance;
     /**
-     * \brief The maximum content light level.
+     * \brief The maximum content light level (MaxCLL).
      *
-     * The value is in units of 0.0001 candelas per square metre.
+     * The value is in units of 1 candelas per square metre.
      */
     uint16_t    max_content_light_level;
     /**
-     * \brief The maximum picture average light level.
+     * \brief The maximum picture average light level (MaxFALL).
      *
-     * The value is in units of 0.0001 candelas per square metre.
+     * The value is in units of 1 candelas per square metre.
      */
     uint16_t    max_pic_average_light_level;
     /** Resevered */


### PR DESCRIPTION
MaxCLL and MaxFALL should be in units of 1 nit as
specified in CEA-861.3, Appendix A.

A uint16_t is not large enough to specify the full
range of possible MaxCLL/MaxFALL values in units of
0.0001 cd/m^2.  So conclude that the documentation
was just a copy/paste error.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>