### PR TITLE
Update dri/vaapi driver mapping for iris

### DIFF
--- a/va/drm/va_drm_utils.c
+++ b/va/drm/va_drm_utils.c
@@ -37,6 +37,8 @@ struct driver_name_map {
 };
 
 static const struct driver_name_map g_driver_name_map[] = {
+    { "iris",       4, "iHD"    }, // Intel Media driver with Iris DRI driver
+    { "iris",       4, "i965"   }, // Intel OTC GenX driver with Iris DRI driver
     { "i915",       4, "iHD"    }, // Intel Media driver
     { "i915",       4, "i965"   }, // Intel OTC GenX driver
     { "pvrsrvkm",   8, "pvr"    }, // Intel UMG PVR driver


### PR DESCRIPTION
As reported https://github.com/intel/libva/issues/396

Update the driver mapping to take the new Iris intel driver into account

Signed-off-by: Nicolas Chauvet <kwizart@gmail.com>