### PR TITLE
Fixes file descriptor leak

### DIFF
--- a/va/x11/dri2_util.c
+++ b/va/x11/dri2_util.c
@@ -182,8 +182,7 @@ va_isDRI2Connected(VADriverContextP ctx, char **driver_name)
     char *device_name = NULL;
     drm_magic_t magic;        
     *driver_name = NULL;
-    dri_state->base.fd = -1;
-    dri_state->base.auth_type = VA_NONE;
+
     if (!VA_DRI2QueryExtension(ctx->native_dpy, &event_base, &error_base))
         goto err_out;
 
@@ -194,6 +193,9 @@ va_isDRI2Connected(VADriverContextP ctx, char **driver_name)
     if (!VA_DRI2Connect(ctx->native_dpy, RootWindow(ctx->native_dpy, ctx->x11_screen),
                      driver_name, &device_name))
         goto err_out;
+
+    if ((dri_state->base.fd != -1) && (dri_state->base.auth_type != VA_NONE))
+        goto success_out;
 
     dri_state->base.fd = open(device_name, O_RDWR);
 
@@ -215,6 +217,7 @@ va_isDRI2Connected(VADriverContextP ctx, char **driver_name)
     dri_state->close = dri2Close;
     gsDRI2SwapAvailable = (minor >= 2);
 
+success_out:
     Xfree(device_name);
 
     return True;

--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -287,6 +287,9 @@ VADisplay vaGetDisplay (
         return NULL;
     }
 
+    dri_state->base.fd = -1;
+    dri_state->base.auth_type = VA_NONE;
+
     pDriverContext->drm_state = dri_state;
 
     return (VADisplay)pDisplayContext;


### PR DESCRIPTION
If code calls va_isDRI2Connected multiple times there is no protection
against calling open(device_name, O_RDWR) again and losing the reference
to the original file descriptor.

A recent change (bc8a12) calls the method twice each time libva is
initialized, thus causing a leak of device file descriptors.

This change moves the initializing of the fd and auth_type to the
creation of the dri_state and then checks to see if they have already
been initialized. If so, the method va_isDRIConnected returns true
and fills in driver_name.