### PR TITLE
trace: divide va_TraceEndPicture to two seperate function

### DIFF
--- a/va/va.c
+++ b/va/va.c
@@ -1612,12 +1612,11 @@ VAStatus vaEndPicture (
   ctx = CTX(dpy);
 
   VA_FOOL_FUNC(va_FoolCheckContinuity, dpy);
-
+  VA_TRACE_ALL(va_TraceEndPicture, dpy, context, 0);
   va_status = ctx->vtable->vaEndPicture( ctx, context );
-
-  /* dump surface content */
-  VA_TRACE_ALL(va_TraceEndPicture, dpy, context, 1);
   VA_TRACE_RET(dpy, va_status);
+  /* dump surface content */
+  VA_TRACE_ALL(va_TraceEndPictureExt, dpy, context, 1);
 
   return va_status;
 }

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -5658,9 +5658,6 @@ void va_TracePutSurface (
 
 void va_TraceStatus(VADisplay dpy, const char * funcName, VAStatus status)
 {
-    if(status == VA_STATUS_SUCCESS)
-        return;
-
     DPY2TRACE_VIRCTX(dpy);
 
     va_TraceMsg(trace_ctx, "=========%s ret = %s, %s \n",funcName, vaStatusStr(status), vaErrorStr(status));

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -5402,14 +5402,23 @@ void va_TraceEndPicture(
     int endpic_done
 )
 {
-    int encode, decode, jpeg;
     DPY2TRACECTX(dpy, context, VA_INVALID_ID);
 
     TRACE_FUNCNAME(idx);
 
     va_TraceMsg(trace_ctx, "\tcontext = 0x%08x\n", context);
     va_TraceMsg(trace_ctx, "\trender_targets = 0x%08x\n", trace_ctx->trace_rendertarget);
+    va_TraceMsg(trace_ctx, NULL);
+}
 
+void va_TraceEndPictureExt(
+    VADisplay dpy,
+    VAContextID context,
+    int endpic_done
+)
+{
+    int encode, decode, jpeg;
+    DPY2TRACECTX(dpy, context, VA_INVALID_ID);
     /* avoid to create so many empty files */
     encode = (trace_ctx->trace_entrypoint == VAEntrypointEncSlice);
     decode = (trace_ctx->trace_entrypoint == VAEntrypointVLD);
@@ -5425,9 +5434,7 @@ void va_TraceEndPicture(
         vaSyncSurface(dpy, trace_ctx->trace_rendertarget);
         va_TraceSurface(dpy, context);
     }
-
-    va_TraceMsg(trace_ctx, NULL);
-}
+ }
 
 
 void va_TraceSyncSurface(

--- a/va/va_trace.h
+++ b/va/va_trace.h
@@ -200,6 +200,13 @@ void va_TraceEndPicture(
 );
 
 DLL_HIDDEN
+void va_TraceEndPictureExt(
+    VADisplay dpy,
+    VAContextID context,
+    int endpic_done
+);
+
+DLL_HIDDEN
 void va_TraceSyncSurface(
     VADisplay dpy,
     VASurfaceID render_target


### PR DESCRIPTION
seperate the log and dump

Signed-off-by: Carl Zhang <carl.zhang@intel.com>