### PR TITLE
correct typo hierachical_flag to hierarchical_flag

### DIFF
--- a/va/va_enc_hevc.h
+++ b/va/va_enc_hevc.h
@@ -230,11 +230,16 @@ typedef struct _VAEncSequenceParameterBufferHEVC {
             uint32_t    low_delay_seq                                  : 1;
             /** \brief Indicates whether or not the encoding is in dyadic hierarchical GOP structure
               * the default value 0, BRC would treat is as flat structure. if HierachicalFlag == 1,
+              * application would enable Qp Modulation, depricated for typo
+              */
+            va_deprecated uint32_t    hierachical_flag                 : 1;
+            /** \brief Indicates whether or not the encoding is in dyadic hierarchical GOP structure
+              * the default value 0, BRC would treat is as flat structure. if HierarchicalFlag == 1,
               * application would enable Qp Modulation
               */
-            uint32_t    hierachical_flag                               : 1;
+            uint32_t    hierarchical_flag                              : 1;
             /** \brief keep for future , should be set to 0 */
-            uint32_t    reserved_bits                                  : 14;
+            uint32_t    reserved_bits                                  : 13;
         } bits;
         uint32_t value;
     } seq_fields;


### PR DESCRIPTION
deprecate hierachical_flag
add hierarchical_flag instead

Signed-off-by: Carl Zhang <carl.zhang@intel.com>