### PR TITLE
Travis-ci: added support for ppc64le build along with amd64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: required
 language: c
 compiler: gcc
 os: linux
+arch:
+  - amd64
+  - ppc64le
 
 env:
   global:
@@ -15,6 +18,7 @@ env:
 
 before_install:
   - test "${TRAVIS_BRANCH}" != 'coverity_scan' -o "${TRAVIS_JOB_NUMBER##*.}" = '1' || exit 0
+  - if [ "$TRAVIS_ARCH" = "ppc64le" ]; then sudo apt-get -y update; sudo apt-get -y install systemd; sudo  apt-get -y install dbus; fi
   - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
   - |
      sudo systemctl stop apt-daily.service &&


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjay-cpu/libva/builds/186059891 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!