### PR TITLE
Enable github actions

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,0 +1,18 @@
+name: freebsd
+
+on: [ push, pull_request ]
+
+jobs:
+  freebsd:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: test
+      uses: vmactions/freebsd-vm@v0.0.7
+      with:
+        prepare: |
+          pkg install -y meson pkgconf libdrm libXext libXfixes wayland
+          pkg install -y -x '^mesa($|-libs)'
+        run: |
+          meson _build
+          meson compile -C _build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,70 @@
+name: ubuntu
+
+on: [ push, pull_request ]
+
+jobs:
+  ubuntu-latest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install prerequisites
+      run: sudo apt-get install -y
+        libdrm-dev
+        libegl1-mesa-dev
+        libgl1-mesa-dev
+        libx11-dev
+        libxext-dev
+        libxfixes-dev
+        libwayland-dev
+    - name: configure
+      run: ./autogen.sh --prefix=/usr
+    - name: build
+      run: make
+    - name: check
+      run: make check
+    - name: install
+      run: sudo make install
+
+  ubuntu-20-04:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: install prerequisites
+      run: sudo apt-get install -y
+        libdrm-dev
+        libegl1-mesa-dev
+        libgl1-mesa-dev
+        libx11-dev
+        libxext-dev
+        libxfixes-dev
+        libwayland-dev
+    - name: configure
+      run: ./autogen.sh --prefix=/usr
+    - name: build
+      run: make
+    - name: check
+      run: make check
+    - name: install
+      run: sudo make install
+
+  ubuntu-18-04:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: install prerequisites
+      run: sudo apt-get install -y
+        libdrm-dev
+        libegl1-mesa-dev
+        libgl1-mesa-dev
+        libx11-dev
+        libxext-dev
+        libxfixes-dev
+        libwayland-dev
+    - name: configure
+      run: ./autogen.sh --prefix=/usr
+    - name: build
+      run: make
+    - name: check
+      run: make check
+    - name: install
+      run: sudo make install


### PR DESCRIPTION
Recently Travis CI has significant latency before jobs are actually started. My estimation is around 24h. This significantly delays in time reaction on the PRs and delays merges. For example, we have issue to verify that #363 which introduces BSD support buils correctly. This change is an attempt to switch to github actions which seem to start almost instantly. This also verifies that BSD changes build correctly.

Actions:
* https://github.com/dvrogozh/libva/actions/runs/311038053 - freebsd
* https://github.com/dvrogozh/libva/actions/runs/311038049 - ubuntu
