### PR TITLE
v2.9.0: fix version mismatch between meson and autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ m4_define([va_api_version],
 # - reset micro version to zero when VA-API major or minor version is changed
 m4_define([libva_major_version], [m4_eval(va_api_major_version + 1)])
 m4_define([libva_minor_version], [m4_eval(va_api_minor_version)])
-m4_define([libva_micro_version], [0])
+m4_define([libva_micro_version], [1])
 m4_define([libva_pre_version],   [0])
 
 m4_define([libva_version],

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 # - reset micro version to zero when VA-API major or minor version is changed
 project(
   'libva', 'c',
-  version : '2.9.0.0',
+  version : '2.9.1',
   meson_version : '>= 0.37.0',
   default_options : [ 'warning_level=1',
                       'buildtype=debugoptimized' ])


### PR DESCRIPTION
We got mismatch in release version number for meson (2.9.0.0) and
autotools (2.9.0). To avoid collisions on package managers side
around which version is greater, we will bump release version
to 2.9.1.

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>