### PR TITLE
wayland: don't try to authenticate with render nodes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,7 @@ m4_define([libva_lt_age],
           [m4_eval(libva_binary_age - libva_interface_age)])
 
 # libdrm minimun version requirement
-m4_define([libdrm_version], [2.4])
+m4_define([libdrm_version], [2.4.60])
 
 # Wayland minimum version number
 # 1.11.0 for wl_proxy_create_wrapper

--- a/meson.build
+++ b/meson.build
@@ -75,7 +75,7 @@ configinc = include_directories('.')
 cc = meson.get_compiler('c')
 dl_dep = cc.find_library('dl', required : false)
 
-libdrm_dep = dependency('libdrm', version : '>= 2.4')
+libdrm_dep = dependency('libdrm', version : '>= 2.4.60')
 
 WITH_DRM = not get_option('disable_drm')
 

--- a/va/wayland/va_wayland_drm.c
+++ b/va/wayland/va_wayland_drm.c
@@ -78,8 +78,15 @@ drm_handle_device(void *data, struct wl_drm *drm, const char *device)
     }
 
     drm_state->fd = fd;
-    drmGetMagic(drm_state->fd, &magic);
-    wl_drm_authenticate(wl_drm_ctx->drm, magic);
+
+    int type = drmGetNodeTypeFromFd(fd);
+    if (type != DRM_NODE_RENDER) {
+        drmGetMagic(drm_state->fd, &magic);
+        wl_drm_authenticate(wl_drm_ctx->drm, magic);
+    } else {
+        wl_drm_ctx->is_authenticated = 1;
+        drm_state->auth_type         = VA_DRM_AUTH_CUSTOM;
+    }
 }
 
 static void


### PR DESCRIPTION
When the parent compositor is running with a render node, Mesa will send
the render node path via wl_drm instead of the primary path. DRM
authentication doesn't work with render nodes.

This patch makes the Wayland logic consistent with the DRM logic [1].

Tested using Sway running with wlroots' headless backend.

[1]: https://github.com/intel/libva/blob/b4d0af7f43f0ef2d51f070c75429c0d6acca663b/va/drm/va_drm.c#L68

Signed-off-by: Simon Ser <contact@emersion.fr>