### PR TITLE
AV1 decode documentation edit for superres_scale_denominator

### DIFF
--- a/va/va_dec_av1.h
+++ b/va/va_dec_av1.h
@@ -444,7 +444,8 @@ typedef struct  _VADecPictureParameterBufferAV1
     } pic_info_fields;
 
     /** \brief Supper resolution scale denominator.
-     *  value range [9..16]
+     *  When use_superres=1, superres_scale_denominator must be in the range [9..16].
+     *  When use_superres=0, superres_scale_denominator must be 8.
      */
     uint8_t                 superres_scale_denominator;
 


### PR DESCRIPTION
superres_scale_denominator value was only reflecting range [9..16] which
doesn't match the range mentioned in spec [8..16]. This commit clarifies
that when use_superres=1, superres_scale_denominator value range is
[9..16] otherwise, it is 8.

Signed-off-by: Sushma Venkatesh Reddy <sushma.venkatesh.reddy@intel.com>