### PR TITLE
Remove tile_rows and tile_cols restriction to match AV1 spec

### DIFF
--- a/va/va_dec_av1.h
+++ b/va/va_dec_av1.h
@@ -376,8 +376,7 @@ typedef struct  _VADecPictureParameterBufferAV1
     VAFilmGrainStructAV1    film_grain_info;
 
     /** \brief tile structure
-     *  When uniform_tile_spacing_flag == 1, the value of tile_cols and
-     *  tile_rows need to be power of 2, and width_in_sbs_minus_1[] and
+     *  When uniform_tile_spacing_flag == 1, width_in_sbs_minus_1[] and
      *  height_in_sbs_minus_1[] should be ignored, which will be generated
      *  by driver based on tile_cols and tile_rows.
      */


### PR DESCRIPTION
There is no restriction of tile_rows and tile_cols value in AV1 spec so,
this commit excludes the comment that says value of tile_rows and
tile_cols should be power of 2.

Signed-off-by: Sushma Venkatesh Reddy <sushma.venkatesh.reddy@intel.com>