### PR TITLE
drm: unbreak VA_DRM_IsRenderNodeFd on FreeBSD, v2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,7 @@ m4_define([libva_lt_age],
           [m4_eval(libva_binary_age - libva_interface_age)])
 
 # libdrm minimun version requirement
-m4_define([libdrm_version], [2.4.60])
+m4_define([libdrm_version], [2.4.74])
 
 # Wayland minimum version number
 # 1.11.0 for wl_proxy_create_wrapper

--- a/meson.build
+++ b/meson.build
@@ -75,7 +75,7 @@ configinc = include_directories('.')
 cc = meson.get_compiler('c')
 dl_dep = cc.find_library('dl', required : false)
 
-libdrm_dep = dependency('libdrm', version : '>= 2.4.60')
+libdrm_dep = dependency('libdrm', version : '>= 2.4.74')
 
 WITH_DRM = not get_option('disable_drm')
 

--- a/va/drm/va_drm_utils.c
+++ b/va/drm/va_drm_utils.c
@@ -26,7 +26,6 @@
 
 #include "sysdeps.h"
 #include <xf86drm.h>
-#include <sys/stat.h>
 #include "va_drm_utils.h"
 #include "va_drmcommon.h"
 
@@ -117,12 +116,11 @@ VA_DRM_GetDriverName(VADriverContextP ctx, char **driver_name_ptr, int candidate
 int
 VA_DRM_IsRenderNodeFd(int fd)
 {
-    struct stat st;
     const char *name;
 
     /* Check by device node */
-    if (fstat(fd, &st) == 0)
-        return S_ISCHR(st.st_mode) && (st.st_rdev & 0x80);
+    if (drmGetNodeTypeFromFd(fd) == DRM_NODE_RENDER)
+        return 1;
 
     /* Check by device name */
     name = drmGetDeviceNameFromFd2(fd);

--- a/va/drm/va_drm_utils.c
+++ b/va/drm/va_drm_utils.c
@@ -125,7 +125,7 @@ VA_DRM_IsRenderNodeFd(int fd)
         return S_ISCHR(st.st_mode) && (st.st_rdev & 0x80);
 
     /* Check by device name */
-    name = drmGetDeviceNameFromFd(fd);
+    name = drmGetDeviceNameFromFd2(fd);
     if (name)
         return strncmp(name, "/dev/dri/renderD", 16) == 0;
 


### PR DESCRIPTION
Closes #292. I've added version check.

```diff
--- before
+++ after
@@ -1,24 +1,26 @@
 $ mpv --no-config --msg-level=vd=v --hwdec=vaapi --gpu-context=drm /path/to/foo.mkv
  (+) Video --vid=1 (*) (h264 1920x1080 23.976fps)
  (+) Audio --aid=1 --alang=jpn (*) (aac 2ch 48000Hz)
  (+) Subs  --sid=1 --slang=eng (*) 'English subs' (ass)
 [vd] Container reported FPS: 23.976024
 [vd] Codec list:
 [vd]     h264 - H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10
 [vd]     h264_v4l2m2m (h264) - V4L2 mem2mem H.264 decoder wrapper
 [vd] Opening decoder h264
 [vd] Looking at hwdec h264-vaapi...
-[vd] Could not create device.
-[vd] No hardware decoding available for this codec.
-[vd] Using software decoding.
-[vd] Detected 8 logical cores.
-[vd] Requesting 9 threads for decoding.
+[vd] Trying hardware decoding via h264-vaapi.
+[vd] Pixel formats supported by decoder: vaapi_vld yuv420p
+[vd] Codec profile: High (0x64)
+[vd] Requesting pixfmt 'vaapi_vld' from decoder.
 [vd] Selected codec: h264 (H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10)
-[vd] Using software decoding.
-[vd] Decoder format: 1920x1080 yuv420p auto/auto/auto/auto/auto CL=mpeg2/4/h264
+[vd] Pixel formats supported by decoder: vaapi_vld yuv420p
+[vd] Codec profile: High (0x64)
+[vd] Requesting pixfmt 'vaapi_vld' from decoder.
+Using hardware decoding (vaapi).
+[vd] Decoder format: 1920x1080 vaapi[nv12] auto/auto/auto/auto/auto CL=mpeg2/4/h264
 [vd] Using container aspect ratio.
 AO: [oss] 48000Hz stereo 2ch s32
-VO: [gpu] 1920x1080 yuv420p
+VO: [gpu] 1920x1080 vaapi[nv12]
 AV: 00:00:00 / 00:23:52 (0%) A-V: -0.000
 
 Exiting... (Quit)
```
