### PR TITLE
Modify AV1 frame_width_minus1 and frame_height_minus1 comment

### DIFF
--- a/va/va_dec_av1.h
+++ b/va/va_dec_av1.h
@@ -325,7 +325,6 @@ typedef struct  _VADecPictureParameterBufferAV1
     /** \brief Picture resolution minus 1
      *  Picture original resolution. If SuperRes is enabled,
      *  this is the upscaled resolution.
-     *  The value may not be multiple of 8.
      *  value range [0..65535]
      */
     uint16_t                frame_width_minus1;


### PR DESCRIPTION
AV1 does not have any frame resolution restrictions. However, the comment
"value may not be multiple of 8" was confusing so, I am excluding it to be
in sync with the AV1 spec.

Signed-off-by: Sushma Venkatesh Reddy <sushma.venkatesh.reddy@intel.com>