### PR TITLE
Introduce VASurfaceAttribDRMFormatModifiers

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -1581,6 +1581,13 @@ typedef enum {
     /** \brief Surface usage hint, gives the driver a hint of intended usage 
      *  to optimize allocation (e.g. tiling) (int, read/write). */
     VASurfaceAttribUsageHint,
+    /** \brief List of possible DRM format modifiers (pointer, write).
+     *
+     * The value must be a pointer to a VADRMFormatModifierList. This can only
+     * be used when allocating a new buffer, it's invalid to use this attribute
+     * when importing an existing buffer.
+     */
+    VASurfaceAttribDRMFormatModifiers,
     /** \brief Number of surface attributes. */
     VASurfaceAttribCount
 } VASurfaceAttribType;

--- a/va/va_drmcommon.h
+++ b/va/va_drmcommon.h
@@ -154,5 +154,22 @@ typedef struct _VADRMPRIMESurfaceDescriptor {
     } layers[4];
 } VADRMPRIMESurfaceDescriptor;
 
+/**
+ * \brief List of DRM format modifiers.
+ *
+ * To allocate surfaces with one of the modifiers specified in the array, call
+ * vaCreateSurfaces() with the VASurfaceAttribDRMFormatModifiers attribute set
+ * to point to an array of num_surfaces instances of this structure. The driver
+ * will select the optimal modifier in the list.
+ *
+ * DRM format modifiers are defined in drm_fourcc.h in the Linux kernel.
+ */
+typedef struct _VADRMFormatModifierList {
+	/** Number of modifiers. */
+	uint32_t num_modifiers;
+	/** Array of modifiers. */
+	uint64_t *modifiers;
+} VADRMFormatModifierList;
+
 
 #endif /* VA_DRM_COMMON_H */


### PR DESCRIPTION
This allows users to specify a list of modifiers when allocating a
new surface. The driver will pick a modifier from the list.

Example usage:

```c
// List of modifiers suitable for the buffer usage, coming from e.g. EGL or KMS
uint64_t modifiers[2] = {
    I915_FORMAT_MOD_X_TILED,
    I915_FORMAT_MOD_Y_TILED,
};
VADRMFormatModifierList modifier_list = {
    .num_modifiers = 2,
    .modifiers = modifiers,
};

VASurfaceAttrib attribs[2] = {0};
attribs[0].type = VASurfaceAttribPixelFormat;
attribs[0].value.type = VAGenericValueTypeInteger;
attribs[0].value.value.i = VA_FOURCC_NV12;
attribs[1].type = VASurfaceAttribDRMFormatModifiers;
attribs[1].value.type = VAGenericValueTypePointer;
attribs[1].value.value.p = &modifier_list;

VASurfaceID surface;
vaCreateSurfaces(display, VA_RT_FORMAT_YUV420, width, height, &surface, 1, attribs, 2);
```

Closes: https://github.com/intel/libva/issues/502