### PR TITLE
vp9enc: update log2_tile_column description

### DIFF
--- a/va/va_enc_vp9.h
+++ b/va/va_enc_vp9.h
@@ -472,7 +472,7 @@ typedef struct  _VAEncPictureParameterBufferVP9
 
     /** \brief log2 of number of tile columns
      *  Corresponds to the same VP9 syntax element in frame header.
-     *  value range [0..5]
+     *  value range [0..6]
      */
     uint8_t     log2_tile_columns;
 


### PR DESCRIPTION
Increase the value range of the log2_tile_column field of VP9 encoding
picture parameter buffer structure from [0..5] to [0..6] to align with
updates to the underlying SW/HW stack.

Signed-off-by: vasiliy.buzoverya@intel.com