### PR TITLE
Document unsupported attrib error for vaCreateSurfaces

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -1714,6 +1714,9 @@ vaQuerySurfaceAttributes(
  * be constructed based on what the underlying hardware could expose
  * through vaQuerySurfaceAttributes().
  *
+ * If one of the attributes is not supported, this function returns
+ * \c VA_STATUS_ERROR_ATTR_NOT_SUPPORTED.
+ *
  * @param[in] dpy               the VA display
  * @param[in] format            the desired surface format. See \c VA_RT_FORMAT_*
  * @param[in] width             the surface width


### PR DESCRIPTION
This documents that drivers shouldn't silently ignore unknown
attributes. See also [1] and [2].

[1]: https://github.com/intel/media-driver/pull/1176
[2]: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/10104