### PR TITLE
Add lookahead interfaces for HEVC

### DIFF
--- a/va/va_str.c
+++ b/va/va_str.c
@@ -148,6 +148,7 @@ const char *vaConfigAttribTypeStr(VAConfigAttribType configAttribType)
         TOSTR(VAConfigAttribEncAV1Ext1);
         TOSTR(VAConfigAttribEncAV1Ext2);
         TOSTR(VAConfigAttribEncPerBlockControl);
+        TOSTR(VAConfigAttribLookAhead);
     case VAConfigAttribTypeMax:
         break;
     }


### PR DESCRIPTION
Add attribute #VAConfigAttribLookAhead, VALookAheadInfo
and corresponing params in HEVC SPS and PPS for supporting HEV lookahead.