### PR TITLE
meson: Copy public headers to build directory

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@
 project(
   'libva', 'c',
   version : '2.14.0.1',
-  meson_version : '>= 0.37.0',
+  meson_version : '>= 0.53.0',
   default_options : [ 'warning_level=1',
                       'buildtype=debugoptimized' ])
 
@@ -103,7 +103,7 @@ if get_option('with_wayland') != 'no'
   wayland_dep = dependency('wayland-client', version : '>= 1.11.0',
 			   required : get_option('with_wayland') == 'yes')
   if wayland_dep.found()
-    wl_prefix = wayland_dep.get_pkgconfig_variable('prefix')
+    wl_prefix = wayland_dep.get_variable(pkgconfig: 'prefix')
     wl_scanner = find_program('wayland-scanner',
 			      wl_prefix + '/bin/wayland-scanner')
   endif

--- a/pkgconfig/meson.build
+++ b/pkgconfig/meson.build
@@ -1,39 +1,50 @@
-pkgconf = configuration_data()
+pkg = import('pkgconfig')
 
-pkgconf.set('prefix', get_option('prefix'))
-pkgconf.set('exec_prefix', '${prefix}')
-pkgconf.set('libdir', join_paths(get_option('prefix'), get_option('libdir')))
-pkgconf.set('includedir', join_paths(get_option('prefix'), get_option('includedir')))
-pkgconf.set('LIBVA_VERSION', libva_version)
-pkgconf.set('VA_API_VERSION', va_api_version)
-pkgconf.set('LIBVA_DRIVERS_PATH', driverdir)
+vars = ['libva_version=' + libva_version, 'va_api_version=' + va_api_version]
 
-pkg_install_dir = '@0@/pkgconfig'.format(get_option('libdir'))
-
-pkg_files = [ 'libva' ]
+va_vars = vars + ['driverdir=' + driverdir]
+pkg.generate(libva,
+  description: 'Userspace Video Acceleration (VA) core interface',
+  filebase: 'libva',
+  variables: va_vars,
+  version: va_api_version)
 
 if WITH_DRM
-  pkg_files += [ 'libva-drm' ]
+  drm_vars = vars + ['display=drm']
+  pkg.generate(libva_drm,
+    description: 'Userspace Video Acceleration (VA) DRM interface',
+    filebase: 'libva-drm',
+    requires: 'libva',
+    variables: drm_vars,
+    version: va_api_version)
 endif
 
 if WITH_X11
-  pkg_files += [ 'libva-x11' ]
+  x11_vars = vars + ['display=x11']
+  pkg.generate(libva_x11,
+    description: 'Userspace Video Acceleration (VA) X11 interface',
+    filebase: 'libva-x11',
+    requires: 'libva',
+    variables: x11_vars,
+    version: va_api_version)
 endif
 
 if WITH_GLX
-  pkg_files += [ 'libva-glx' ]
+  glx_vars = vars + ['display=glx']
+  pkg.generate(libva_glx,
+    description: 'Userspace Video Acceleration (VA) GLX interface',
+    filebase: 'libva-glx',
+    requires: 'libva',
+    variables: glx_vars,
+    version: va_api_version)
 endif
 
 if WITH_WAYLAND
-  pkg_files += [ 'libva-wayland' ]
+  wayland_vars = vars + ['display=wayland']
+  pkg.generate(libva_wayland,
+    description: 'Userspace Video Acceleration (VA) Wayland interface',
+    filebase: 'libva-wayland',
+    requires: 'libva, wayland-client',
+    variables: wayland_vars,
+    version: va_api_version)
 endif
-
-foreach p : pkg_files
-  infile = p + '.pc.in'
-  outfile = p + '.pc'
-  configure_file(
-    input : infile,
-    output : outfile,
-    configuration : pkgconf,
-    install_dir : pkg_install_dir)
-endforeach

--- a/va/meson.build
+++ b/va/meson.build
@@ -46,6 +46,9 @@ libva_headers = [
   version_file,
 ]
 
+# headers that have be copied for subprojects
+libva_headers_subproject = []
+
 libva_headers_priv = [
   'sysdeps.h',
   'va_fool.h',
@@ -87,6 +90,8 @@ if WITH_DRM
   libva_drm_headers = [
     'drm/va_drm.h',
   ]
+
+  libva_headers_subproject += libva_drm_headers
 
   libva_drm_headers_priv = [
     'drm/va_drm_auth.h',
@@ -134,11 +139,14 @@ if WITH_X11
     'x11/va_x11.c',
   ]
 
-  libva_x11_headers = [
-    'va_x11.h',
+  libva_dri_headers = [
     'x11/va_dri2.h',
     'x11/va_dricommon.h',
   ]
+
+  libva_x11_headers = ['va_x11.h'] + libva_dri_headers
+
+  libva_headers_subproject += libva_dri_headers
 
   libva_x11_headers_priv = [
     'x11/va_dri2str.h',
@@ -178,6 +186,8 @@ if WITH_GLX
     'glx/va_glx.h',
   ]
 
+  libva_headers_subproject += libva_glx_headers
+
   libva_glx_headers_priv = [
     'glx/va_glx_impl.h',
     'glx/va_glx_private.h',
@@ -215,6 +225,8 @@ if WITH_WAYLAND
     'wayland/va_backend_wayland.h',
     'wayland/va_wayland.h',
   ]
+
+  libva_headers_subproject += libva_wayland_headers
 
   libva_wayland_headers_priv = [
     'wayland/va_wayland_drm.h',
@@ -256,3 +268,8 @@ if WITH_WAYLAND
     include_directories : configinc,
     dependencies : deps)
 endif
+
+fs = import('fs')
+foreach header : libva_headers_subproject
+  configure_file(output: fs.name(header), input: header, copy: true)
+endforeach


### PR DESCRIPTION
In order to use libva in a [subproject](https://mesonbuild.com/Subprojects.html) or in an "uninstalled" environment, libva needs to fix its public headers layout in its source directory. A [previous fix was proposed](intel#433) which moved those headers as expected, but it was closed because it was too
invasive.

This new approach is less invasive and oriented to meson subprojects or uninstalled setups, which has a wider audience.

The fix is two-fold:

1. Bump the required version of meson in order to support this new feature. And update deprecated syntax.
2. Copy each public header file into subproject's build directory.