### PR TITLE
build: Wayland scanner should generate private code.

### DIFF
--- a/va/meson.build
+++ b/va/meson.build
@@ -239,7 +239,7 @@ if WITH_WAYLAND
       'wayland-drm-client-protocol.c',
       output : 'wayland-drm-client-protocol.c',
       input : 'wayland/wayland-drm.xml',
-      command : [wl_scanner, 'code', '@INPUT@', '@OUTPUT@']),
+      command : [wl_scanner, 'private-code', '@INPUT@', '@OUTPUT@']),
 
     custom_target(
       'wayland-drm-client-protocol.h',

--- a/va/wayland/Makefile.am
+++ b/va/wayland/Makefile.am
@@ -68,7 +68,7 @@ va_wayland_drm.c: $(protocol_source_h)
 %-client-protocol.h : %.xml
 	$(AM_V_GEN)$(WAYLAND_SCANNER) client-header < $< > $@
 %-client-protocol-export.c : %.xml
-	$(AM_V_GEN)$(WAYLAND_SCANNER) code < $< > $@
+	$(AM_V_GEN)$(WAYLAND_SCANNER) private-code < $< > $@
 %-client-protocol.c: %-client-protocol-export.c
 	$(AM_V_GEN){ echo '#include "sysdeps.h"'; $(SED) \
 		-e 's@WL_EXPORT@DLL_HIDDEN@g' \


### PR DESCRIPTION
wayland-scanner emits a warning:

Using "code" is deprecated - use private-code or public-code.
See the help page for details.

This patch updates argument to private-code.