### PR TITLE
VA/X11: add crocus mapping

### DIFF
--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -55,6 +55,7 @@ static const struct driver_name_map g_dri2_driver_name_map[] = {
     { "i965",       4, "i965"   }, // Intel i965 VAAPI driver with i965 DRI driver
     { "iris",       4, "iHD"    }, // Intel iHD  VAAPI driver with iris DRI driver
     { "iris",       4, "i965"   }, // Intel i965 VAAPI driver with iris DRI driver
+    { "crocus",     6, "i965"   }, // Intel i965 VAAPI driver with crocus DRI driver
     { NULL,         0, NULL }
 };
 


### PR DESCRIPTION
Fixes https://github.com/intel/intel-vaapi-driver/issues/533
Fixes https://github.com/intel/libva/issues/548
Closes https://github.com/intel/libva/pull/549 (duplicate)
Closes https://github.com/intel/libva/pull/550 (duplicate)
See https://gitlab.freedesktop.org/mesa/mesa/-/blob/21.3/include/pci_ids/crocus_pci_ids.h
Dogfooding via https://github.com/freebsd/freebsd-ports/commit/bbdb8c12e8ac

Disclaimer: Runtime hasn't been tested. I only have Skylake where this is nop.