### PR TITLE
VA/X11: add mapping for crocus DRI driver

### DIFF
--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -55,6 +55,7 @@ static const struct driver_name_map g_dri2_driver_name_map[] = {
     { "i965",       4, "i965"   }, // Intel i965 VAAPI driver with i965 DRI driver
     { "iris",       4, "iHD"    }, // Intel iHD  VAAPI driver with iris DRI driver
     { "iris",       4, "i965"   }, // Intel i965 VAAPI driver with iris DRI driver
+    { "crocus",     4, "i965"   }, // Intel i965 VAAPI driver with crocus DRI driver
     { NULL,         0, NULL }
 };
 


### PR DESCRIPTION
Just add a mapping for crocus