### PR TITLE
Add nvidia-drm to the DRM driver map

### DIFF
--- a/va/drm/va_drm_utils.c
+++ b/va/drm/va_drm_utils.c
@@ -45,6 +45,7 @@ static const struct driver_name_map g_driver_name_map[] = {
     { "nouveau",    7, "nouveau"  }, // Mesa Gallium driver
     { "radeon",     6, "r600"     }, // Mesa Gallium driver
     { "amdgpu",     6, "radeonsi" }, // Mesa Gallium driver
+    { "nvidia-drm",10, "nvidia"   }, // NVIDIA driver
     { NULL,         0, NULL }
 };
 


### PR DESCRIPTION
This PR adds the nvidia-drm driver to the DRM driver map. It maps it to existing 'nvidia' VA-API driver, matching the X11 driver.

This change is needed to support an upcoming VA-API implementation based off NVDEC, currently not public.