### PR TITLE
Change the default log level from info to errors

### DIFF
--- a/va/va.c
+++ b/va/va.c
@@ -119,8 +119,12 @@ int vaDisplayIsValid(VADisplay dpy)
  * Global log level configured from the config file or environment, which sets
  * whether default logging appears or not (always overridden by explicitly
  * user-configured logging).
+ *
+ * 0 = nothing
+ * 1 = errors only
+ * 2 = informational messages
  */
-static int default_log_level = 2;
+static int default_log_level = 1;
 
 static void default_log_error(void *user_context, const char *buffer)
 {


### PR DESCRIPTION
libva by default writes log messages to stdout, but the stdouts of GUI
applications are connected to the systemd journal these days.

This results in a lot of unnecessarily repeated log messages of the form
> libva info: VA-API version 1.13.0
> libva info: Trying to open /usr/lib64/dri/radeonsi_drv_video.so
> libva info: Found init function __vaDriverInit_1_13
> libva info: va_openDriver() returns 0
as e.g. Firefox creates and destroys video decoders for page elements.

This patch reduces the default log level from info to errors only.

Signed-off-by: Nicholas Miell <nmiell@gmail.com>