### PR TITLE
va_glx_impl: set `GLX_ALPHA_SIZE, 8` when creating pixmap

### DIFF
--- a/va/glx/va_glx_impl.c
+++ b/va/glx/va_glx_impl.c
@@ -521,6 +521,7 @@ static int create_tfp_surface(VADriverContextP ctx, VASurfaceGLXP pSurfaceGLX)
         GLX_RED_SIZE,           8,
         GLX_GREEN_SIZE,         8,
         GLX_BLUE_SIZE,          8,
+        GLX_ALPHA_SIZE,         8,
         /*
          * depth test isn't enabled in the implementaion of VA GLX,
          * so depth buffer is unnecessary. However to workaround a
@@ -535,8 +536,6 @@ static int create_tfp_surface(VADriverContextP ctx, VASurfaceGLXP pSurfaceGLX)
     for (attrib = fbconfig_attrs; *attrib != GL_NONE; attrib += 2)
         ;
     if (wattr.depth == 32) {
-        *attrib++ = GLX_ALPHA_SIZE;
-        *attrib++ = 8;
         *attrib++ = GLX_BIND_TO_TEXTURE_RGBA_EXT;
         *attrib++ = GL_TRUE;
     } else {


### PR DESCRIPTION
Since Mesa 18.X or higher allow_rgb1O_configs is set to true by default,
Not specifying the alpha leads to taking a 1O bit GLXFBConfig which leads
to corrupted rendering


Signed-off-by: Mouhamad Kebe <mouhamad.kebe@blade-group.com>