### PR TITLE
Added VAConfigAttribType VAConfigAttribMaxInputStreams for video

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -1028,6 +1028,13 @@ typedef enum {
      * The value returned uses the VAConfigAttribValEncPerBlockControl type.
      */
     VAConfigAttribEncPerBlockControl    = 55,
+    /**
+     * \brief Maximum number of input streams for video composition in video processing. Read-only.
+     *
+     * This attribute determines the maximum number of input streams which the driver supports for
+     * a given configuration.
+     */
+    VAConfigAttribMaxInputStreams       = 56,
     /**@}*/
     VAConfigAttribTypeMax
 } VAConfigAttribType;


### PR DESCRIPTION
composition in video processing.

This attribute determines the maximum number of input streams which the driver supports for a given configuration.

Signed-off-by: Furong Zhang <furong.zhang@intel.com>