### PR TITLE
Revert "Add av1e hierarchy level info."

### DIFF
--- a/va/va_enc_av1.h
+++ b/va/va_enc_av1.h
@@ -249,10 +249,7 @@ typedef struct  _VAEncSequenceParameterBufferAV1 {
      */
     uint8_t     seq_tier;
 
-    /** \brief Indicates whether or not the encoding is in dyadic hierarchical GOP structure.
-     *  value range [0..1].
-     */
-    uint8_t    HierarchicalFlag; 
+    uint8_t     reserved8b;
 
     /** \brief Period between intra_only frames. */
     uint32_t    intra_period;
@@ -584,11 +581,7 @@ typedef struct  _VAEncPictureParameterBufferAV1
      */
     uint8_t     ref_frame_idx[7];
 
-    /** \brief When hierarchical_level_plus1 > 0, hierarchical_level_plus1-1 indicates
-     *  the current frame's level. If VAEncMiscParameterTemporalLayerStructure
-     *  is valid (number_of_layers >0), hierarchical_level_plus1 shouldn't larger than number_of_layers.
-     */
-    uint8_t     hierarchical_level_plus1;
+    uint8_t     reserved8bits0;
 
     /** \brief primary reference frame.
      *  Index into reference_frames[]


### PR DESCRIPTION
Reverts intel/libva#583

there are no issue with this PR itself
it is because media_driver has a violation, to faster enable features, it used reserved byte before the PR merged. after that , new libva + old media-driver will failed,  old libva + new media driver also will failed.
will re-aply similar patch which will use other reserved byte instead current 2 (reserved8b, reserved8bits0), 

and current 2 (reserved8b, reserved8bits0) will be kept there, should not change the variable name for next 2 releases 
