### PR TITLE
Maint: Removed waffle-io badge from README to fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Stories in Ready](https://badge.waffle.io/intel/libva.png?label=ready&title=Ready)](http://waffle.io/intel/libva)
 [![Build Status](https://travis-ci.org/intel/libva.svg?branch=master)](https://travis-ci.org/intel/libva)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/11605/badge.svg)](https://scan.coverity.com/projects/intel-libva)
 
@@ -9,7 +8,7 @@ Libva is an implementation for VA-API (Video Acceleration API)
 VA-API is an open-source library and API specification, which
 provides access to graphics hardware acceleration capabilities
 for video processing. It consists of a main library and
-driver-specific acceleration backends for each supported hardware 
+driver-specific acceleration backends for each supported hardware
 vendor.
 
 If you would like to contribute to libva, check our [Contributing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-[![Build Status](https://travis-ci.org/intel/libva.svg?branch=master)](https://travis-ci.org/intel/libva)
-[![Coverity Scan Build Status](https://scan.coverity.com/projects/11605/badge.svg)](https://scan.coverity.com/projects/intel-libva)
-
 # Libva Project
 
 Libva is an implementation for VA-API (Video Acceleration API)


### PR DESCRIPTION
Since waffle.io has shut down in 2019, the broken badge and its link
will not be fixed at the destination.

Removing the badge is the only resolution.

Fixes #609

Signed-off-by: Oleksandr Pavlyk <oleksandr.pavlyk@intel.com>