### PR TITLE
meson: set HAVE_VA_X11 when applicable

### DIFF
--- a/va/meson.build
+++ b/va/meson.build
@@ -101,9 +101,10 @@ if WITH_DRM
   deps = [ libdrm_dep ]
 
   libva_drm_args = []
-  if get_option('with_x11') != 'no' and x11_dep.found()
+  if WITH_X11
     libva_drm_sources += [ 'drm/va_drm_auth_x11.c' ]
     libva_drm_args += [
+      '-DHAVE_VA_X11',
       '-DLIBVA_MAJOR_VERSION=@0@'.format(libva_major_version)
     ]
     deps += [ x11_dep ]


### PR DESCRIPTION
Without the define, we'll end without the Xorg auth whenever the DRM
display is used.

---

Team please consider porting this for the stable releases.
Thanks