### PR TITLE
Fix driver probing, DRI3 and Xwayland support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -270,7 +270,7 @@ AM_CONDITIONAL(USE_DRM, test "$USE_DRM" = "yes")
 # Check for X11
 USE_X11="no"
 if test "x$enable_x11" != "xno"; then
-    PKG_CHECK_MODULES([X11],    [x11 xext xfixes],    [USE_X11="yes"], [:])
+    PKG_CHECK_MODULES([X11],    [x11 xext xfixes x11-xcb xcb xcb-dri3],    [USE_X11="yes"], [:])
 
     if test "x$USE_X11" = "xno" -a "x$enable_x11" = "xyes"; then
        AC_MSG_ERROR([VA/X11 explicitly enabled, however $X11_PKG_ERRORS])

--- a/meson.build
+++ b/meson.build
@@ -86,6 +86,11 @@ if get_option('with_x11') != 'no'
   xfixes_dep = dependency('xfixes', required : get_option('with_x11') == 'yes')
 
   WITH_X11 = (x11_dep.found() and xext_dep.found() and xfixes_dep.found())
+
+  x11_xcb_dep = dependency('x11-xcb', required : get_option('with_x11') == 'yes')
+  xcb_dep = dependency('xcb', required : get_option('with_x11') == 'yes')
+  xcb_dri3_dep = dependency('xcb-dri3', required : get_option('with_x11') == 'yes')
+  WITH_X11 = (WITH_X11 and x11_xcb_dep.found() and xcb_dep.found() and xcb_dri3_dep.found())
 endif
 
 if not WITH_X11 and get_option('with_glx') == 'yes'

--- a/va/drm/va_drm.c
+++ b/va/drm/va_drm.c
@@ -97,9 +97,9 @@ vaGetDisplayDRM(int fd)
     VADisplayContextP pDisplayContext = NULL;
     VADriverContextP  pDriverContext  = NULL;
     struct drm_state *drm_state       = NULL;
-    int is_render_nodes;
+    int node_type;
 
-    if (fd < 0 || (is_render_nodes = VA_DRM_IsRenderNodeFd(fd)) < 0)
+    if (fd < 0 || (node_type = drmGetNodeTypeFromFd(fd)) < 0)
         return NULL;
 
     /* Create new entry */
@@ -123,7 +123,7 @@ vaGetDisplayDRM(int fd)
         goto error;
 
     pDriverContext->native_dpy   = NULL;
-    pDriverContext->display_type = is_render_nodes ?
+    pDriverContext->display_type = node_type == DRM_NODE_RENDER ?
                                    VA_DISPLAY_DRM_RENDERNODES : VA_DISPLAY_DRM;
     pDriverContext->drm_state    = drm_state;
 

--- a/va/drm/va_drm_utils.c
+++ b/va/drm/va_drm_utils.c
@@ -40,6 +40,7 @@ static const struct driver_name_map g_driver_name_map[] = {
     { "i915",       "i965"   }, // Intel OTC GenX driver
     { "pvrsrvkm",   "pvr"    }, // Intel UMG PVR driver
     { "radeon",     "r600"     }, // Mesa Gallium driver
+    { "radeon",     "radeonsi" }, // Mesa Gallium driver
     { "amdgpu",     "radeonsi" }, // Mesa Gallium driver
     { "nvidia-drm", "nvidia"   }, // NVIDIA driver
     { NULL,         NULL }

--- a/va/drm/va_drm_utils.c
+++ b/va/drm/va_drm_utils.c
@@ -137,23 +137,3 @@ VA_DRM_GetDriverName(VADriverContextP ctx, char **driver_name_ptr, int candidate
 
     return VA_STATUS_SUCCESS;
 }
-
-/* Checks whether the file descriptor is a DRM Render-Nodes one */
-int
-VA_DRM_IsRenderNodeFd(int fd)
-{
-    struct stat st;
-    const char *name;
-
-    /* Check by device node */
-    if (fstat(fd, &st) == 0)
-        return S_ISCHR(st.st_mode) && (st.st_rdev & 0x80);
-
-    /* Check by device name */
-    name = drmGetDeviceNameFromFd(fd);
-    if (name)
-        return strncmp(name, "/dev/dri/renderD", 16) == 0;
-
-    /* Unrecoverable error */
-    return -1;
-}

--- a/va/drm/va_drm_utils.h
+++ b/va/drm/va_drm_utils.h
@@ -66,16 +66,6 @@ DLL_HIDDEN
 VAStatus
 VA_DRM_GetDriverName(VADriverContextP ctx, char **driver_name_ptr, int candidate_index);
 
-/**
- * \brief Checks whether the file descriptor is a DRM Render-Nodes one
- *
- * This functions checks whether the supplied file descriptor @fd
- * falls into the set of DRM Render-Nodes.
- */
-DLL_HIDDEN
-int
-VA_DRM_IsRenderNodeFd(int fd);
-
 /**@}*/
 
 #ifdef __cplusplus

--- a/va/meson.build
+++ b/va/meson.build
@@ -133,6 +133,8 @@ if WITH_X11
   libva_x11_sources = [
     'x11/dri2_util.c',
     'x11/va_dri2.c',
+    'x11/va_dri3.c',
+    'drm/va_drm_utils.c',
     'x11/va_dricommon.c',
     'x11/va_fglrx.c',
     'x11/va_nvctrl.c',
@@ -151,13 +153,14 @@ if WITH_X11
   libva_x11_headers_priv = [
     'x11/va_dri2str.h',
     'x11/va_dri2tokens.h',
+    'x11/va_dri3.h',
     'x11/va_fglrx.h',
     'x11/va_nvctrl.h',
   ]
 
   install_headers(libva_x11_headers, subdir : 'va')
 
-  deps = [ libdrm_dep, x11_dep, xext_dep, xfixes_dep, libva_dep ]
+  deps = [ libdrm_dep, x11_dep, xext_dep, xfixes_dep, x11_xcb_dep, xcb_dep, xcb_dri3_dep, libva_dep ]
 
   libva_x11 = shared_library(
     'va-x11',

--- a/va/x11/Makefile.am
+++ b/va/x11/Makefile.am
@@ -30,6 +30,8 @@ AM_CPPFLAGS = \
 source_c = \
 	dri2_util.c		\
 	va_dri2.c		\
+	va_dri3.c		\
+	../drm/va_drm_utils.c	\
 	va_dricommon.c		\
 	va_fglrx.c		\
 	va_nvctrl.c		\
@@ -44,11 +46,12 @@ source_h = \
 source_h_priv = \
 	va_dri2str.h		\
 	va_dri2tokens.h		\
+	va_dri3.h		\
 	va_fglrx.h		\
 	va_nvctrl.h		\
 	$(NULL)
 
-noinst_LTLIBRARIES		= libva_x11.la	
+noinst_LTLIBRARIES		= libva_x11.la
 libva_x11includedir		= ${includedir}/va
 libva_x11include_HEADERS	= $(source_h)
 libva_x11_la_SOURCES		= $(source_c)

--- a/va/x11/va_dri3.c
+++ b/va/x11/va_dri3.c
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2022 Collabora Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Soft-
+ * ware"), to deal in the Software without restriction, including without
+ * limitation the rights to use, copy, modify, merge, publish, distribute,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, provided that the above copyright
+ * notice(s) and this permission notice appear in all copies of the Soft-
+ * ware and that both the above copyright notice(s) and this permission
+ * notice appear in supporting documentation.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+ * ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY
+ * RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN
+ * THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSE-
+ * QUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+ * DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+ * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFOR-
+ * MANCE OF THIS SOFTWARE.
+ *
+ * Except as contained in this notice, the name of a copyright holder shall
+ * not be used in advertising or otherwise to promote the sale, use or
+ * other dealings in this Software without prior written authorization of
+ * the copyright holder.
+ *
+ * Authors:
+ *   Emil Velikov (emil.velikov@collabora.com)
+ */
+
+#include "sysdeps.h"
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+
+#include <xcb/xcb.h>
+#include <xcb/dri3.h>
+
+#include <X11/Xlib-xcb.h>
+#include <xf86drm.h>
+
+#include "va_backend.h"
+#include "va_drmcommon.h"
+#include "drm/va_drm_utils.h"
+
+static xcb_screen_t *
+va_DRI3GetXCBScreen(xcb_connection_t *conn, int screen)
+{
+    xcb_screen_iterator_t iter;
+
+    iter = xcb_setup_roots_iterator(xcb_get_setup(conn));
+    for (; iter.rem; --screen, xcb_screen_next(&iter))
+        if (screen == 0)
+            return iter.data;
+    return NULL;
+}
+
+static int
+va_isDRI3Connected(VADriverContextP ctx, int *outfd)
+{
+    xcb_connection_t *conn = XGetXCBConnection(ctx->native_dpy);
+    xcb_screen_t *screen;
+    xcb_window_t root;
+    const xcb_query_extension_reply_t *ext;
+    xcb_dri3_open_cookie_t cookie;
+    xcb_dri3_open_reply_t *reply;
+    int fd;
+    char *render_node;
+
+    if (!conn)
+        return -1;
+
+    screen = va_DRI3GetXCBScreen(conn, ctx->x11_screen);
+    if (!screen)
+        return -1;
+
+    root = screen->root;
+
+    xcb_prefetch_extension_data(conn, &xcb_dri3_id);
+    ext = xcb_get_extension_data(conn, &xcb_dri3_id);
+    if (!ext || !ext->present)
+        return -1;
+
+    /* We don't require any of the ancy stuff, so there's no point in checking
+     * the version.
+     */
+
+    cookie = xcb_dri3_open(conn, root, 0 /* provider */);
+    reply = xcb_dri3_open_reply(conn, cookie, NULL /* error */);
+
+    if (!reply || reply->nfd != 1) {
+        free(reply);
+        return -1;
+    }
+
+    fd = xcb_dri3_open_reply_fds(conn, reply)[0];
+    free(reply);
+
+    /* The server can give us primary or a render node.
+     * In case of the former we need to swap it for the latter.
+     */
+    switch (drmGetNodeTypeFromFd(fd)) {
+    case DRM_NODE_PRIMARY:
+        render_node = drmGetRenderDeviceNameFromFd(fd);
+        close(fd);
+        if (!render_node)
+            return -1;
+
+        fd = open(render_node, O_RDWR | O_CLOEXEC);
+        free(render_node);
+        if (fd == -1)
+            return -1;
+
+        break;
+    case DRM_NODE_RENDER:
+        fcntl(fd, F_SETFD, fcntl(fd, F_GETFD) | FD_CLOEXEC);
+        break;
+    default:
+        close(fd);
+        return -1;
+    }
+
+    *outfd = fd;
+    return 0;
+}
+
+VAStatus va_DRI3_GetNumCandidates(
+    VADisplayContextP pDisplayContext,
+    int *num_candidates
+)
+{
+    VADriverContextP const ctx = pDisplayContext->pDriverContext;
+    struct drm_state * drm_state = (struct drm_state *)ctx->drm_state;
+    int fd = -1;
+
+    if (va_isDRI3Connected(ctx, &fd) && fd != -1)
+        return VA_STATUS_ERROR_UNKNOWN;
+
+    drm_state->fd = fd;
+    drm_state->auth_type = VA_DRM_AUTH_CUSTOM;
+    return VA_DRM_GetNumCandidates(ctx, num_candidates);
+}
+
+VAStatus va_DRI3_GetDriverName(
+    VADisplayContextP pDisplayContext,
+    char **driver_name,
+    int candidate_index
+)
+{
+    VADriverContextP const ctx = pDisplayContext->pDriverContext;
+
+    return VA_DRM_GetDriverName(ctx, driver_name, candidate_index);
+}

--- a/va/x11/va_dri3.h
+++ b/va/x11/va_dri3.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2022 Collabora Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Soft-
+ * ware"), to deal in the Software without restriction, including without
+ * limitation the rights to use, copy, modify, merge, publish, distribute,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, provided that the above copyright
+ * notice(s) and this permission notice appear in all copies of the Soft-
+ * ware and that both the above copyright notice(s) and this permission
+ * notice appear in supporting documentation.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+ * ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY
+ * RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN
+ * THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSE-
+ * QUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+ * DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+ * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFOR-
+ * MANCE OF THIS SOFTWARE.
+ *
+ * Except as contained in this notice, the name of a copyright holder shall
+ * not be used in advertising or otherwise to promote the sale, use or
+ * other dealings in this Software without prior written authorization of
+ * the copyright holder.
+ *
+ * Authors:
+ *   Emil Velikov (emil.velikov@collabora.com)
+ */
+
+#ifndef _VA_DRI3_H_
+#define _VA_DRI3_H_
+
+#include "sysdeps.h"
+#include "va_backend.h"
+
+DLL_HIDDEN
+VAStatus va_DRI3_GetNumCandidates(
+    VADisplayContextP pDisplayContext,
+    int *num_candidates
+);
+
+DLL_HIDDEN
+VAStatus va_DRI3_GetDriverName(
+    VADisplayContextP pDisplayContext,
+    char **driver_name_ptr,
+    int candidate_index
+);
+
+#endif


### PR DESCRIPTION
This MR fixes some pre-existing bugs in the libva (backend) driver handling and adds DRI3 support.

In other words:
  - the correct module is picked on radeon (drm) + radeonsi (mesa/va) drivers
  - ~~the LIBVA_DRIVER_NAME override works correctly~~ pulled out for now
  - the render-node is properly detected, in some corner case
  - DRI3 Xserver and Xwayland works.

Note: Only DRI3 open/fd retrieval is added enough for GetDisplay. All the winsys part is deliberately omitted, since it is heavily driver specific and makes little sense to add here.

In practise the x11/wayland winsys code in libva-{x11,wayland} has never been appealing enough to be used in the Mesa VA drivers. If i965 (legacy intel-driver) or iHD (new intel-media-driver) are interested they can adapt it to their needs.