### PR TITLE
Tweak the va driver-name mappings

### DIFF
--- a/va/drm/va_drm_utils.c
+++ b/va/drm/va_drm_utils.c
@@ -39,9 +39,6 @@ static const struct driver_name_map g_driver_name_map[] = {
     { "i915",       "iHD"    }, // Intel Media driver
     { "i915",       "i965"   }, // Intel OTC GenX driver
     { "pvrsrvkm",   "pvr"    }, // Intel UMG PVR driver
-    { "emgd",       "emgd"   }, // Intel ECG PVR driver
-    { "hybrid",     "hybrid" }, // Intel OTC Hybrid driver
-    { "nouveau",    "nouveau"  }, // Mesa Gallium driver
     { "radeon",     "r600"     }, // Mesa Gallium driver
     { "amdgpu",     "radeonsi" }, // Mesa Gallium driver
     { "nvidia-drm", "nvidia"   }, // NVIDIA driver

--- a/va/drm/va_drm_utils.c
+++ b/va/drm/va_drm_utils.c
@@ -32,21 +32,20 @@
 
 struct driver_name_map {
     const char *key;
-    int         key_len;
     const char *name;
 };
 
 static const struct driver_name_map g_driver_name_map[] = {
-    { "i915",       4, "iHD"    }, // Intel Media driver
-    { "i915",       4, "i965"   }, // Intel OTC GenX driver
-    { "pvrsrvkm",   8, "pvr"    }, // Intel UMG PVR driver
-    { "emgd",       4, "emgd"   }, // Intel ECG PVR driver
-    { "hybrid",     6, "hybrid" }, // Intel OTC Hybrid driver
-    { "nouveau",    7, "nouveau"  }, // Mesa Gallium driver
-    { "radeon",     6, "r600"     }, // Mesa Gallium driver
-    { "amdgpu",     6, "radeonsi" }, // Mesa Gallium driver
-    { "nvidia-drm",10, "nvidia"   }, // NVIDIA driver
-    { NULL,         0, NULL }
+    { "i915",       "iHD"    }, // Intel Media driver
+    { "i915",       "i965"   }, // Intel OTC GenX driver
+    { "pvrsrvkm",   "pvr"    }, // Intel UMG PVR driver
+    { "emgd",       "emgd"   }, // Intel ECG PVR driver
+    { "hybrid",     "hybrid" }, // Intel OTC Hybrid driver
+    { "nouveau",    "nouveau"  }, // Mesa Gallium driver
+    { "radeon",     "r600"     }, // Mesa Gallium driver
+    { "amdgpu",     "radeonsi" }, // Mesa Gallium driver
+    { "nvidia-drm", "nvidia"   }, // NVIDIA driver
+    { NULL,         NULL }
 };
 
 /* Returns the VA driver candidate num for the active display*/
@@ -63,8 +62,7 @@ VA_DRM_GetNumCandidates(VADriverContextP ctx, int * num_candidates)
     if (!drm_version)
         return VA_STATUS_ERROR_UNKNOWN;
     for (m = g_driver_name_map; m->key != NULL; m++) {
-        if (drm_version->name_len >= m->key_len &&
-            strncmp(drm_version->name, m->key, m->key_len) == 0) {
+        if (strcmp(m->key, drm_version->name) == 0) {
             count ++;
         }
     }
@@ -93,8 +91,7 @@ VA_DRM_GetDriverName(VADriverContextP ctx, char **driver_name_ptr, int candidate
         return VA_STATUS_ERROR_UNKNOWN;
 
     for (m = g_driver_name_map; m->key != NULL; m++) {
-        if (drm_version->name_len >= m->key_len &&
-            strncmp(drm_version->name, m->key, m->key_len) == 0) {
+        if (strcmp(m->key, drm_version->name) == 0) {
             if (current_index == candidate_index) {
                 break;
             }

--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -45,17 +45,16 @@
 
 struct driver_name_map {
     const char *key;
-    int         key_len;
     const char *name;
 };
 
 static const struct driver_name_map g_dri2_driver_name_map[] = {
-    { "i965",       4, "iHD"    }, // Intel iHD  VAAPI driver with i965 DRI driver
-    { "i965",       4, "i965"   }, // Intel i965 VAAPI driver with i965 DRI driver
-    { "iris",       4, "iHD"    }, // Intel iHD  VAAPI driver with iris DRI driver
-    { "iris",       4, "i965"   }, // Intel i965 VAAPI driver with iris DRI driver
-    { "crocus",     6, "i965"   }, // Intel i965 VAAPI driver with crocus DRI driver
-    { NULL,         0, NULL }
+    { "i965",       "iHD"    }, // Intel iHD  VAAPI driver with i965 DRI driver
+    { "i965",       "i965"   }, // Intel i965 VAAPI driver with i965 DRI driver
+    { "iris",       "iHD"    }, // Intel iHD  VAAPI driver with iris DRI driver
+    { "iris",       "i965"   }, // Intel i965 VAAPI driver with iris DRI driver
+    { "crocus",     "i965"   }, // Intel i965 VAAPI driver with crocus DRI driver
+    { NULL,         NULL }
 };
 
 static int va_DisplayContextIsValid(
@@ -102,8 +101,7 @@ static VAStatus va_DRI2_GetNumCandidates(
         return VA_STATUS_ERROR_UNKNOWN;
 
     for (m = g_dri2_driver_name_map; m->key != NULL; m++) {
-        if (strlen(driver_name) >= m->key_len &&
-            strncmp(driver_name, m->key, m->key_len) == 0) {
+        if (strcmp(m->key, driver_name) == 0) {
             (*num_candidates)++;
         }
     }
@@ -136,8 +134,7 @@ static VAStatus va_DRI2_GetDriverName(
         return VA_STATUS_ERROR_UNKNOWN;
 
     for (m = g_dri2_driver_name_map; m->key != NULL; m++) {
-        if (strlen(*driver_name_ptr) >= m->key_len &&
-            strncmp(*driver_name_ptr, m->key, m->key_len) == 0) {
+        if (strcmp(m->key, *driver_name_ptr) == 0) {
             if (current_index == candidate_index) {
                 break;
             }


### PR DESCRIPTION
 - x11: drop the key_len from the mapping table
 - drm: drop the key_len from the mapping table
 - drm: fallback to drm driver-name, like we do in the x11/dri2 codebase
Thus we no longer need PRs like https://github.com/intel/libva/pull/340
 - drm: drop the no longer needed mappings \o/