### PR TITLE
Deprecate legacy emgd, nvctrl and fglrx codebase

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -154,6 +154,21 @@ AC_ARG_ENABLE([va-messaging],
                     [build with va info and error messaging @<:@default=yes@:>@])],
     [], [enable_va_messaging="yes"])
 
+AC_ARG_WITH(legacy,
+    [AC_HELP_STRING([--with-legacy=[[components]]],
+                    [build with legacy components @<:@default=emgd,nvctrl,fglrx@:>@])],
+    [], [with_legacy="emgd,nvctrl,fglrx"])
+
+if test "$with_legacy" = *emgd*; then
+    AC_DEFINE([HAVE_EMGD], [1], [Defined to 1 if EMGD is built])
+fi
+if test "$with_legacy" = *nvctrl*; then
+    AC_DEFINE([HAVE_NVCTRL], [1], [Defined to 1 if NVCTRL is built])
+fi
+if test "$with_legacy" = *fglrx*; then
+    AC_DEFINE([HAVE_FGLRX], [1], [Defined to 1 if FGLRX is built])
+fi
+
 AC_ARG_WITH(drivers-path,
     [AC_HELP_STRING([--with-drivers-path=[[path]]],
                     [drivers path])],
@@ -359,6 +374,7 @@ echo
 echo Installation prefix .............. : $prefix
 echo Default driver path .............. : $LIBVA_DRIVERS_PATH
 echo Extra window systems ............. : $BACKENDS
+echo Build with legacy ................ : $with_legacy
 echo Build documentation .............. : $enable_docs
 echo Build with messaging ............. : $enable_va_messaging
 echo

--- a/meson.build
+++ b/meson.build
@@ -130,6 +130,17 @@ if (not WITH_DRM and not WITH_X11 and not WITH_WAYLAND and not WITH_WIN32)
   error('Please install at least one backend dev files (DRM, X11, Wayland, WIN32)')
 endif
 
+c_args = []
+if get_option('with_legacy').contains('emgd')
+  c_args += ['-DHAVE_EMGD']
+elif get_option('with_legacy').contains('nvctrl')
+  c_args += ['-DHAVE_NVCTRL']
+elif get_option('with_legacy').contains('fglrx')
+  c_args += ['-DHAVE_FGLRX']
+endif
+
+add_project_arguments(c_args, language: ['c'])
+
 subdir('va')
 subdir('pkgconfig')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,5 +4,6 @@ option('with_x11', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'aut
 option('with_glx', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'auto')
 option('with_wayland', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'auto')
 option('with_win32', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'auto')
+option('with_legacy', type : 'array', choices : ['emdg', 'nvctrl', 'fglrx'], value : [])
 option('enable_docs', type : 'boolean', value : false)
 option('enable_va_messaging', type : 'boolean', value : true)

--- a/va/wayland/va_wayland.c
+++ b/va/wayland/va_wayland.c
@@ -110,10 +110,12 @@ static const struct va_wayland_backend g_backends[] = {
         va_wayland_drm_create,
         va_wayland_drm_destroy
     },
+#ifdef HAVE_EMGD
     {
         va_wayland_emgd_create,
         va_wayland_emgd_destroy
     },
+#endif
     { NULL, }
 };
 

--- a/va/wayland/va_wayland_emgd.c
+++ b/va/wayland/va_wayland_emgd.c
@@ -25,6 +25,9 @@
  */
 
 #include "sysdeps.h"
+
+#ifdef HAVE_EMGD
+
 #include <unistd.h>
 #include <dlfcn.h>
 #include "va_drmcommon.h"
@@ -154,3 +157,5 @@ va_wayland_emgd_create(VADisplayContextP pDisplayContext)
         return false;
     return true;
 }
+
+#endif

--- a/va/wayland/va_wayland_emgd.h
+++ b/va/wayland/va_wayland_emgd.h
@@ -27,6 +27,8 @@
 #ifndef VA_WAYLAND_EMGD_H
 #define VA_WAYLAND_EMGD_H
 
+#ifdef HAVE_EMGD
+
 #include <stdbool.h>
 #include "va_wayland.h"
 #include "va_backend.h"
@@ -48,5 +50,7 @@ va_wayland_emgd_create(VADisplayContextP pDisplayContext);
 DLL_HIDDEN
 void
 va_wayland_emgd_destroy(VADisplayContextP pDisplayContext);
+
+#endif
 
 #endif /* VA_WAYLAND_EMGD_H */

--- a/va/x11/va_fglrx.c
+++ b/va/x11/va_fglrx.c
@@ -23,6 +23,9 @@
  */
 
 #include "sysdeps.h"
+
+#ifdef HAVE_FGLRX
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -268,3 +271,5 @@ VAStatus va_FGLRX_GetDriverName(
 
     return VA_STATUS_SUCCESS;
 }
+
+#endif

--- a/va/x11/va_fglrx.h
+++ b/va/x11/va_fglrx.h
@@ -25,6 +25,8 @@
 #ifndef VA_FGLRX_H
 #define VA_FGLRX_H
 
+#ifdef HAVE_FGLRX
+
 #include <X11/Xlib.h>
 #include "va_backend.h"
 
@@ -34,5 +36,7 @@ VAStatus va_FGLRX_GetDriverName(
     char **driver_name,
     int candidate_index
 );
+
+#endif
 
 #endif /* VA_FGLRX_H */

--- a/va/x11/va_fglrx.h
+++ b/va/x11/va_fglrx.h
@@ -26,10 +26,13 @@
 #define VA_FGLRX_H
 
 #include <X11/Xlib.h>
+#include "va_backend.h"
 
 DLL_HIDDEN
-Bool VA_FGLRXGetClientDriverName(Display *dpy, int screen,
-                                 int *ddxDriverMajorVersion, int *ddxDriverMinorVersion,
-                                 int *ddxDriverPatchVersion, char **clientDriverName);
+VAStatus va_FGLRX_GetDriverName(
+    VADisplayContextP pDisplayContext,
+    char **driver_name,
+    int candidate_index
+);
 
 #endif /* VA_FGLRX_H */

--- a/va/x11/va_nvctrl.c
+++ b/va/x11/va_nvctrl.c
@@ -23,6 +23,9 @@
 
 #define _GNU_SOURCE 1
 #include "sysdeps.h"
+
+#ifdef HAVE_NVCTRL
+
 #include <string.h>
 
 #define NEED_REPLIES
@@ -429,3 +432,5 @@ VAStatus va_NVCTRL_GetDriverName(
 
     return VA_STATUS_SUCCESS;
 }
+
+#endif

--- a/va/x11/va_nvctrl.c
+++ b/va/x11/va_nvctrl.c
@@ -340,7 +340,7 @@ static Bool XNVCTRLQueryStringAttribute(
 }
 
 
-Bool VA_NVCTRLQueryDirectRenderingCapable(Display *dpy, int screen,
+static Bool VA_NVCTRLQueryDirectRenderingCapable(Display *dpy, int screen,
         Bool *isCapable)
 {
     int event_base;
@@ -358,9 +358,9 @@ Bool VA_NVCTRLQueryDirectRenderingCapable(Display *dpy, int screen,
     return True;
 }
 
-Bool VA_NVCTRLGetClientDriverName(Display *dpy, int screen,
-                                  int *ddxDriverMajorVersion, int *ddxDriverMinorVersion,
-                                  int *ddxDriverPatchVersion, char **clientDriverName)
+static Bool VA_NVCTRLGetClientDriverName(Display *dpy, int screen,
+        int *ddxDriverMajorVersion, int *ddxDriverMinorVersion,
+        int *ddxDriverPatchVersion, char **clientDriverName)
 {
     if (ddxDriverMajorVersion)
         *ddxDriverMajorVersion = 0;
@@ -401,4 +401,31 @@ Bool VA_NVCTRLGetClientDriverName(Display *dpy, int screen,
         *clientDriverName = strdup("nvidia");
 
     return True;
+}
+
+VAStatus va_NVCTRL_GetDriverName(
+    VADisplayContextP pDisplayContext,
+    char **driver_name,
+    int candidate_index
+)
+{
+    VADriverContextP ctx = pDisplayContext->pDriverContext;
+    int direct_capable, driver_major, driver_minor, driver_patch;
+    Bool result;
+
+    if (candidate_index != 0)
+        return VA_STATUS_ERROR_INVALID_PARAMETER;
+
+    result = VA_NVCTRLQueryDirectRenderingCapable(ctx->native_dpy, ctx->x11_screen,
+             &direct_capable);
+    if (!result || !direct_capable)
+        return VA_STATUS_ERROR_UNKNOWN;
+
+    result = VA_NVCTRLGetClientDriverName(ctx->native_dpy, ctx->x11_screen,
+                                          &driver_major, &driver_minor,
+                                          &driver_patch, driver_name);
+    if (!result)
+        return VA_STATUS_ERROR_UNKNOWN;
+
+    return VA_STATUS_SUCCESS;
 }

--- a/va/x11/va_nvctrl.h
+++ b/va/x11/va_nvctrl.h
@@ -24,6 +24,8 @@
 #ifndef VA_NVCTRLLIB_H
 #define VA_NVCTRLLIB_H
 
+#ifdef HAVE_NVCTRL
+
 #include <X11/Xlib.h>
 #include "va_backend.h"
 
@@ -33,5 +35,7 @@ VAStatus va_NVCTRL_GetDriverName(
     char **driver_name,
     int candidate_index
 );
+
+#endif
 
 #endif /* VA_NVCTRLLIB_H */

--- a/va/x11/va_nvctrl.h
+++ b/va/x11/va_nvctrl.h
@@ -25,14 +25,13 @@
 #define VA_NVCTRLLIB_H
 
 #include <X11/Xlib.h>
+#include "va_backend.h"
 
 DLL_HIDDEN
-Bool VA_NVCTRLQueryDirectRenderingCapable(Display *dpy, int screen,
-        Bool *isCapable);
-
-DLL_HIDDEN
-Bool VA_NVCTRLGetClientDriverName(Display *dpy, int screen,
-                                  int *ddxDriverMajorVersion, int *ddxDriverMinorVersion,
-                                  int *ddxDriverPatchVersion, char **clientDriverName);
+VAStatus va_NVCTRL_GetDriverName(
+    VADisplayContextP pDisplayContext,
+    char **driver_name,
+    int candidate_index
+);
 
 #endif /* VA_NVCTRLLIB_H */

--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -162,33 +162,6 @@ static VAStatus va_DRI2_GetDriverName(
     return VA_STATUS_SUCCESS;
 }
 
-static VAStatus va_NVCTRL_GetDriverName(
-    VADisplayContextP pDisplayContext,
-    char **driver_name,
-    int candidate_index
-)
-{
-    VADriverContextP ctx = pDisplayContext->pDriverContext;
-    int direct_capable, driver_major, driver_minor, driver_patch;
-    Bool result;
-
-    if (candidate_index != 0)
-        return VA_STATUS_ERROR_INVALID_PARAMETER;
-
-    result = VA_NVCTRLQueryDirectRenderingCapable(ctx->native_dpy, ctx->x11_screen,
-             &direct_capable);
-    if (!result || !direct_capable)
-        return VA_STATUS_ERROR_UNKNOWN;
-
-    result = VA_NVCTRLGetClientDriverName(ctx->native_dpy, ctx->x11_screen,
-                                          &driver_major, &driver_minor,
-                                          &driver_patch, driver_name);
-    if (!result)
-        return VA_STATUS_ERROR_UNKNOWN;
-
-    return VA_STATUS_SUCCESS;
-}
-
 static VAStatus va_FGLRX_GetDriverName(
     VADisplayContextP pDisplayContext,
     char **driver_name,

--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -177,10 +177,14 @@ static VAStatus va_DisplayContextGetDriverName(
     vaStatus = va_DRI3_GetDriverName(pDisplayContext, driver_name, candidate_index);
     if (vaStatus != VA_STATUS_SUCCESS)
         vaStatus = va_DRI2_GetDriverName(pDisplayContext, driver_name, candidate_index);
+#ifdef HAVE_NVCTRL
     if (vaStatus != VA_STATUS_SUCCESS)
         vaStatus = va_NVCTRL_GetDriverName(pDisplayContext, driver_name, candidate_index);
+#endif
+#ifdef HAVE_FGLRX
     if (vaStatus != VA_STATUS_SUCCESS)
         vaStatus = va_FGLRX_GetDriverName(pDisplayContext, driver_name, candidate_index);
+#endif
 
     return vaStatus;
 }

--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -162,28 +162,6 @@ static VAStatus va_DRI2_GetDriverName(
     return VA_STATUS_SUCCESS;
 }
 
-static VAStatus va_FGLRX_GetDriverName(
-    VADisplayContextP pDisplayContext,
-    char **driver_name,
-    int candidate_index
-)
-{
-    VADriverContextP ctx = pDisplayContext->pDriverContext;
-    int driver_major, driver_minor, driver_patch;
-    Bool result;
-
-    if (candidate_index != 0)
-        return VA_STATUS_ERROR_INVALID_PARAMETER;
-
-    result = VA_FGLRXGetClientDriverName(ctx->native_dpy, ctx->x11_screen,
-                                         &driver_major, &driver_minor,
-                                         &driver_patch, driver_name);
-    if (!result)
-        return VA_STATUS_ERROR_UNKNOWN;
-
-    return VA_STATUS_SUCCESS;
-}
-
 static VAStatus va_DisplayContextGetDriverName(
     VADisplayContextP pDisplayContext,
     char **driver_name, int candidate_index


### PR DESCRIPTION
With this MR we move all the emgd, nvctrl and fglrx code into the respective files.
Followed by a way to disable building it - disabled by default with meson, enabled (no switch) with autotools.

This code has not been relevant for distributions for a decade or so.