### PR TITLE
CI: upgrade FreeBSD version to avoid future breakage

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   freebsd:
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v2
     - name: test
-      uses: vmactions/freebsd-vm@v0.1.5
+      uses: vmactions/freebsd-vm@v0
       with:
         prepare: |
           pkg install -y meson pkgconf libdrm libXext libXfixes wayland


### PR DESCRIPTION
FreeBSD Project currently doesn't keep recent binary packages for EOL versions. `/release_0` packages (non-default) frozen at 13.0 release (2021-04-13) will remain after 13.0 EOL (2022-08-31) for 13.* branch lifetime (until 2026-01-31) but maybe too old for libva CI.