### PR TITLE
ci: add clang-15 coverage and rearrange runners

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,8 +11,46 @@ on:
     - '!.github/workflows/ubuntu.yml'
 
 jobs:
-  ubuntu-latest:
-    runs-on: ubuntu-latest
+  clang-15:
+    runs-on: ubuntu-22.04
+    env:
+      CC: /usr/bin/clang-15
+      CXX: /usr/bin/clang++-15
+      ASM: /usr/bin/clang-15
+    steps:
+    - uses: actions/checkout@v2
+    - name: install toolchain
+      run: |
+        if [[ -e $CC && -e $CXX ]]; then \
+          echo "clang-15 already presents in the image"; \
+        else \
+          echo "clang-15 missed in the image, installing from llvm"; \
+          echo "deb [trusted=yes] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" | sudo tee -a /etc/apt/sources.list; \
+          sudo apt-get update; \
+          sudo apt-get install -y --no-install-recommends clang-15; \
+        fi
+    - name: install prerequisites
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libdrm-dev \
+          libegl1-mesa-dev \
+          libgl1-mesa-dev \
+          libx11-dev \
+          libxext-dev \
+          libxfixes-dev \
+          libwayland-dev
+    - name: configure
+      run: ./autogen.sh --prefix=/usr
+    - name: build
+      run: make
+    - name: check
+      run: make check
+    - name: install
+      run: sudo make install
+
+  ubuntu-22-04:
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: install prerequisites
@@ -59,26 +97,3 @@ jobs:
     - name: install
       run: sudo make install
 
-  ubuntu-18-04:
-    runs-on: ubuntu-18.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: install prerequisites
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          libdrm-dev \
-          libegl1-mesa-dev \
-          libgl1-mesa-dev \
-          libx11-dev \
-          libxext-dev \
-          libxfixes-dev \
-          libwayland-dev
-    - name: configure
-      run: ./autogen.sh --prefix=/usr
-    - name: build
-      run: make
-    - name: check
-      run: make check
-    - name: install
-      run: sudo make install

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -10,6 +10,9 @@ on:
     - '.github/workflows/**'
     - '!.github/workflows/ubuntu.yml'
 
+env:
+  CFLAGS: -Wall -Werror
+
 jobs:
   clang-15:
     runs-on: ubuntu-22.04

--- a/va/x11/va_nvctrl.c
+++ b/va/x11/va_nvctrl.c
@@ -130,7 +130,8 @@ static /* const */ char *nvctrl_extension_name = NV_CONTROL_NAME;
 #define XNVCTRLSimpleCheckExtension(dpy,i) \
   XextSimpleCheckExtension (dpy, i, nvctrl_extension_name)
 
-static int close_display();
+static XEXT_GENERATE_CLOSE_DISPLAY(close_display, nvctrl_ext_info)
+
 static /* const */ XExtensionHooks nvctrl_extension_hooks = {
     NULL,                               /* create_gc */
     NULL,                               /* copy_gc */
@@ -149,8 +150,6 @@ static XEXT_GENERATE_FIND_DISPLAY(find_display, nvctrl_ext_info,
                                   nvctrl_extension_name,
                                   &nvctrl_extension_hooks,
                                   NV_CONTROL_EVENTS, NVCTRL_EXT_NEED_CHECK)
-
-static XEXT_GENERATE_CLOSE_DISPLAY(close_display, nvctrl_ext_info)
 
 static Bool XNVCTRLQueryVersion(Display *dpy, int *major, int *minor);
 


### PR DESCRIPTION
Ubuntu 18.04 runner is deprecated and needs to be removed by 12/1/22
Ubuntu 22.04 runner is now officially supported and we can add it
clang-15 is a latest clang compiler we can also add

This PR also fixes #620 and strengthens ci with -Werror.

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>