### PR TITLE
Misc wayland-scanner fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ ltmain.sh
 missing
 stamp-h1
 /va/va_version.h
-/va/wayland/wayland-drm-client-protocol-export.c
 /va/wayland/wayland-drm-client-protocol.*
 /doc/Doxyfile
 /doc/html-out

--- a/configure.ac
+++ b/configure.ac
@@ -327,7 +327,7 @@ if test "x$enable_wayland" != "xno"; then
 
         AC_PATH_PROG([WAYLAND_SCANNER], [wayland-scanner])
         if test "x$WAYLAND_SCANNER" = "x"; then
-            PKG_CHECK_MODULES([WL_SCANNER], [wayland-scanner],
+            PKG_CHECK_MODULES([WL_SCANNER], [wayland-scanner >= 1.15],
                 [USE_WAYLAND="yes"], [:])
 
             if test "x$USE_WAYLAND" = "xno" -a "x$enable_wayland" = "xyes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -325,11 +325,15 @@ if test "x$enable_wayland" != "xno"; then
 
     if test "$USE_WAYLAND" = "yes"; then
 
-        WAYLAND_PREFIX=`$PKG_CONFIG --variable=prefix wayland-client`
-        AC_PATH_PROG([WAYLAND_SCANNER], [wayland-scanner],,
-                     [${WAYLAND_PREFIX}/bin$PATH_SEPARATOR$PATH])
+        AC_PATH_PROG([WAYLAND_SCANNER], [wayland-scanner])
         if test "x$WAYLAND_SCANNER" = "x"; then
-            AC_MSG_ERROR([wayland-scanner not found: Install it or use --disable-wayland])
+            PKG_CHECK_MODULES([WL_SCANNER], [wayland-scanner],
+                [USE_WAYLAND="yes"], [:])
+
+            if test "x$USE_WAYLAND" = "xno" -a "x$enable_wayland" = "xyes"; then
+                AC_MSG_ERROR([wayland explicitly enabled, however $WL_SCANNER_PKG_ERRORS])
+            fi
+            AC_SUBST(WAYLAND_SCANNER, `$PKG_CONFIG --variable=wayland_scanner wayland-scanner`)
         fi
 
         AC_DEFINE([HAVE_VA_WAYLAND], [1],

--- a/meson.build
+++ b/meson.build
@@ -102,12 +102,12 @@ WITH_WAYLAND = false
 if get_option('with_wayland') != 'no'
   wayland_dep = dependency('wayland-client', version : '>= 1.11.0',
 			   required : get_option('with_wayland') == 'yes')
-  if wayland_dep.found()
-    wl_prefix = wayland_dep.get_variable(pkgconfig: 'prefix')
-    wl_scanner = find_program('wayland-scanner',
-			      wl_prefix + '/bin/wayland-scanner')
+  wayland_scanner_dep = dependency('wayland-scanner',
+                                   required : get_option('with_wayland') == 'yes')
+  if wayland_scanner_dep.found()
+    wl_scanner = find_program(wayland_scanner_dep.get_variable(pkgconfig: 'wayland_scanner'))
   endif
-  WITH_WAYLAND = wayland_dep.found()
+  WITH_WAYLAND = wayland_dep.found() and wayland_scanner_dep.found()
 endif
 
 va_c_args = []

--- a/meson.build
+++ b/meson.build
@@ -102,7 +102,7 @@ WITH_WAYLAND = false
 if get_option('with_wayland') != 'no'
   wayland_dep = dependency('wayland-client', version : '>= 1.11.0',
 			   required : get_option('with_wayland') == 'yes')
-  wayland_scanner_dep = dependency('wayland-scanner',
+  wayland_scanner_dep = dependency('wayland-scanner', version : '>= 1.15',
                                    required : get_option('with_wayland') == 'yes',
                                    native : true)
   if wayland_scanner_dep.found()

--- a/meson.build
+++ b/meson.build
@@ -103,7 +103,8 @@ if get_option('with_wayland') != 'no'
   wayland_dep = dependency('wayland-client', version : '>= 1.11.0',
 			   required : get_option('with_wayland') == 'yes')
   wayland_scanner_dep = dependency('wayland-scanner',
-                                   required : get_option('with_wayland') == 'yes')
+                                   required : get_option('with_wayland') == 'yes',
+                                   native : true)
   if wayland_scanner_dep.found()
     wl_scanner = find_program(wayland_scanner_dep.get_variable(pkgconfig: 'wayland_scanner'))
   endif

--- a/va/meson.build
+++ b/va/meson.build
@@ -239,7 +239,7 @@ if WITH_WAYLAND
       'wayland-drm-client-protocol.c',
       output : 'wayland-drm-client-protocol.c',
       input : 'wayland/wayland-drm.xml',
-      command : [wl_scanner, 'code', '@INPUT@', '@OUTPUT@']),
+      command : [wl_scanner, 'private-code', '@INPUT@', '@OUTPUT@']),
 
     custom_target(
       'wayland-drm-client-protocol.h',

--- a/va/wayland/Makefile.am
+++ b/va/wayland/Makefile.am
@@ -45,10 +45,6 @@ source_h_priv = \
 	va_wayland_private.h	\
 	$(NULL)
 
-protocol_source_export_c = \
-	wayland-drm-client-protocol-export.c	\
-	$(NULL)
-
 protocol_source_c = \
 	wayland-drm-client-protocol.c	\
 	$(NULL)
@@ -67,18 +63,14 @@ noinst_HEADERS			= $(source_h_priv)
 va_wayland_drm.c: $(protocol_source_h)
 %-client-protocol.h : %.xml
 	$(AM_V_GEN)$(WAYLAND_SCANNER) client-header < $< > $@
-%-client-protocol-export.c : %.xml
-	$(AM_V_GEN)$(WAYLAND_SCANNER) code < $< > $@
-%-client-protocol.c: %-client-protocol-export.c
-	$(AM_V_GEN){ echo '#include "sysdeps.h"'; $(SED) \
-		-e 's@WL_EXPORT@DLL_HIDDEN@g' \
-		< $<; } > $@
+%-client-protocol.c : %.xml
+	$(AM_V_GEN)$(WAYLAND_SCANNER) private-code < $< > $@
 
 EXTRA_DIST = \
 	wayland-drm.xml         \
 	$(NULL)
 
-BUILT_SOURCES = $(protocol_source_h) $(protocol_source_c) $(protocol_source_export_c)
+BUILT_SOURCES = $(protocol_source_h) $(protocol_source_c)
 CLEANFILES = $(BUILT_SOURCES)
 
 # Extra clean files so that maintainer-clean removes *everything*


### PR DESCRIPTION
While skimming at the wayland-scanner code/private-code aka a few more issues showed up in the existing handling:
 - the wayland-client.pc prefix is used to look for wayland-scanner -> while wayland-scanner.pc wayland_scanner var has been a thing for almost a decade
 - meson will not pick the native program, so cross compilation can fail
 - we need a version check 1.15 for wayland-scanner, as well as removing of the existing export.c workaround

This PR supersedes https://github.com/intel/libva/pull/542