### PR TITLE
README: drop mailing list, IRC and Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,4 @@ Doxygen files are regularly updated through Github Pages and can
 be accessed directly through [github pages
 libva](http://intel.github.io/libva/)
 
-The libva development team can be reached via our [mailing
-list](https://lists.01.org/postorius/lists/intel-vaapi-media.lists.01.org) and on IRC
-in channel ##intel-media on [Freenode](https://freenode.net/kb/answer/chat).
-
-We also use [#Slack](https://slack.com) and host [VAAPI Media Slack
-Team](https://intel-media.slack.com).  You can signup by submitting your email 
-address to our [Slack Team invite page](https://slack-join-intel-media.herokuapp.com).
-
-Slack complements our other means of communication.  Pick the one that works
-best for you!
+The libva development team can be reached via github issues.


### PR DESCRIPTION
All three are effectively dead. In particular:
 - the ML has disappeared with the update to HyperKitty
 - Freenode has imploded - channel has not moved to Libera/OFTC
 - Slack is a ghost town - last two maintainers are not even on it

@XinfengZhang @dvrogozh @xhaihao @uartie 