### PR TITLE
va_trace: annotate internal functions with DLL_HIDDEN

### DIFF
--- a/va/va_internal.h
+++ b/va/va_internal.h
@@ -32,9 +32,13 @@ extern "C" {
 #define CTX(dpy) (((VADisplayContextP)dpy)->pDriverContext)
 #define CHECK_DISPLAY(dpy) if( !vaDisplayIsValid(dpy) ) { return VA_STATUS_ERROR_INVALID_DISPLAY; }
 
+DLL_HIDDEN
 void va_errorMessage(VADisplay dpy, const char *msg, ...);
+
+DLL_HIDDEN
 void va_infoMessage(VADisplay dpy, const char *msg, ...);
 
+DLL_HIDDEN
 int  va_parseConfig(char *env, char *env_value);
 
 VADisplayContextP va_newDisplayContext(void);

--- a/va/va_trace.h
+++ b/va/va_trace.h
@@ -474,10 +474,12 @@ void va_TracePutSurface(
     unsigned int flags /* de-interlacing flags */
 );
 
+DLL_HIDDEN
 void va_TraceStatus(VADisplay dpy, const char * funcName, VAStatus status);
 
 /** \brief va_TraceEvent
  * common trace interface to send out trace event with scatterd event data. */
+DLL_HIDDEN
 void va_TraceEvent(
     VADisplay dpy,
     unsigned short id,
@@ -487,6 +489,7 @@ void va_TraceEvent(
 
 /** \brief va_TraceEventBuffers
  * trace buffer interface to send out data in buffers. */
+DLL_HIDDEN
 void va_TraceEventBuffers(
     VADisplay dpy,
     VAContextID context,


### PR DESCRIPTION
Annotate the following functions with DLL_HIDDEN:
 - va_errorMessage
 - va_infoMessage
 - va_parseConfig
 - va_TraceEvent
 - va_TraceEventBuffers
 - va_TraceStatus

The APIs have been used solely within libva.so ever since they were introduced. As such we can safely hide it was never used externally and it's not part of the public API.

--
Couple of the above (aka `va_TraceEvent*`) were added recently with https://github.com/intel/libva/pull/552, others like `va_TraceStatus` have been around since 2019, while the rest have been a thing for even longer.

@lindongw to double-check the `va_TraceEvent` symbols that you've added are meant to be internal-only, correct?
