### PR TITLE
ci: add libx11-xcb-dev libxcb-dri3-dev to trigger X11 backend build

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -40,6 +40,8 @@ jobs:
           libegl1-mesa-dev \
           libgl1-mesa-dev \
           libx11-dev \
+          libx11-xcb-dev \
+          libxcb-dri3-dev \
           libxext-dev \
           libxfixes-dev \
           libwayland-dev
@@ -64,6 +66,8 @@ jobs:
           libegl1-mesa-dev \
           libgl1-mesa-dev \
           libx11-dev \
+          libx11-xcb-dev \
+          libxcb-dri3-dev \
           libxext-dev \
           libxfixes-dev \
           libwayland-dev
@@ -88,6 +92,8 @@ jobs:
           libegl1-mesa-dev \
           libgl1-mesa-dev \
           libx11-dev \
+          libx11-xcb-dev \
+          libxcb-dri3-dev \
           libxext-dev \
           libxfixes-dev \
           libwayland-dev


### PR DESCRIPTION
We forgot to add new packages required by recently merged DRI3 support into our ci install steps. As a result we were building w/o X11 actually. Fixing this now an re-enabling X11 backend build.

See: #635
See: ef1df02 ("x11: add basic DRI3 support")
Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>