### PR TITLE
Fix Windows CI build warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -187,28 +187,6 @@ if test "$enable_va_messaging" = "yes"; then
     AC_DEFINE([ENABLE_VA_MESSAGING], [1], [Defined to 1 if va messaging is needed])
 fi
 
-# Check for __attribute__((visibility()))
-AC_CACHE_CHECK([whether __attribute__((visibility())) is supported],
-    ac_cv_have_gnuc_visibility_attribute,
-    [cat > conftest.c <<EOF
-int foo __attribute__ ((visibility ("hidden"))) = 1;
-int bar __attribute__ ((visibility ("protected"))) = 1;
-EOF
-    ac_cv_have_gnuc_visibility_attribute="no"
-    if ${CC-cc} -Werror -S conftest.c -o conftest.s >/dev/null 2>&1; then
-        if grep '\.hidden.*foo' conftest.s >/dev/null; then
-            if grep '\.protected.*bar' conftest.s >/dev/null; then
-                ac_cv_have_gnuc_visibility_attribute="yes"
-            fi
-        fi
-    fi
-    rm -f conftest.[cs]
-])
-if test "$ac_cv_have_gnuc_visibility_attribute" = "yes"; then
-    AC_DEFINE([HAVE_GNUC_VISIBILITY_ATTRIBUTE], [1],
-              [Defined to 1 if GCC visibility attribute is supported])
-fi
-
 # Check for -ldl (often not required)
 AC_SEARCH_LIBS([dlopen], [dl], [], [
   AC_MSG_ERROR([unable to find the dlopen() function])

--- a/meson.build
+++ b/meson.build
@@ -120,11 +120,6 @@ if get_option('enable_va_messaging')
   va_c_args += ['-DENABLE_VA_MESSAGING=1']
 endif
 
-# Symbol visibility
-if cc.has_argument('-fvisibility=hidden')
-  va_c_args += ['-DHAVE_GNUC_VISIBILITY_ATTRIBUTE']
-endif
-
 WITH_WIN32 = false
 libwin32_dep = []
 if get_option('with_win32') != 'no'

--- a/va/meson.build
+++ b/va/meson.build
@@ -56,7 +56,14 @@ libva_headers_priv = [
 ]
 
 libva_sym = 'libva.syms'
-libva_sym_path = '@0@/@1@'.format(meson.current_source_dir(), libva_sym)
+libva_sym_arg = '-Wl,-version-script,' + '@0@/@1@'.format(meson.current_source_dir(), libva_sym)
+
+libva_link_args = []
+libva_link_depends = []
+if cc.links('', name: '-Wl,--version-script', args: ['-shared', libva_sym_arg])
+  libva_link_args = libva_sym_arg
+  libva_link_depends = libva_sym
+endif
 
 install_headers(libva_headers, subdir : 'va')
 
@@ -70,8 +77,8 @@ libva = shared_library(
   version : libva_lt_version,
   c_args : [ '-DSYSCONFDIR="' + sysconfdir + '"'] + ['-DVA_DRIVERS_PATH="' + driverdir + '"'] + va_c_args,
   include_directories : configinc,
-  link_args : '-Wl,-version-script,' + libva_sym_path,
-  link_depends : libva_sym,
+  link_args : libva_link_args,
+  link_depends : libva_link_depends,
   install : true,
   dependencies : [ dl_dep ])
 

--- a/va/sysdeps.h
+++ b/va/sysdeps.h
@@ -48,12 +48,19 @@
 # include <log/log.h>
 #endif
 
-#if defined __GNUC__ && defined HAVE_GNUC_VISIBILITY_ATTRIBUTE
+// Defines for visibility attribute
+// based on https://gcc.gnu.org/wiki/Visibility
+#if defined _WIN32 || defined __CYGWIN__
+# define DLL_EXPORT __declspec(dllexport)
+# define DLL_HIDDEN
+#else
+#if __GNUC__ >= 4
 # define DLL_HIDDEN __attribute__((visibility("hidden")))
 # define DLL_EXPORT __attribute__((visibility("default")))
 #else
 # define DLL_HIDDEN
 # define DLL_EXPORT
+#endif
 #endif
 
 #endif /* SYSDEPS_H */


### PR DESCRIPTION
Fixes https://github.com/intel/libva/issues/645

See: https://github.com/intel/libva/actions/runs/3298661454
Commit: https://github.com/intel/libva/commit/da4a18fe814c9695f420d466ad3065cebdbe288a

windows-msvc:
`LINK : warning LNK4044: unrecognized option '/Wl,-version-script,D:\a\libva\libva\va/libva.syms'; ignored
`

windows-mingw:
`../va/va_trace.c:947:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]`