### PR TITLE
ci: use matrix, add ubuntu 20.04 + clang-15

### DIFF
--- a/.github/workflows/install-clang.sh
+++ b/.github/workflows/install-clang.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if (( $# != 1 )); then
+	echo Script requires one argument - the clang version to be installed
+	exit 1
+fi
+
+if ! which $CC >/dev/null 2>&1; then
+	case $DISTRO in
+		"ubuntu-22.04") distro_name=jammy;;
+		"ubuntu-20.04") distro_name=focal;;
+		*)
+		echo "Unknown distribution $DISTRO"
+		exit 1
+	esac
+	case $1 in
+		"14" | "15") llvm_version=$1;;
+		*)
+		echo "Unknown llvm version $1"
+		exit 1
+	esac
+
+	sources="deb [trusted=yes] http://apt.llvm.org/$distro_name/ llvm-toolchain-$distro_name-$llvm_version main"
+
+	echo "clang-$llvm_version missed in the image, installing from llvm"
+	echo "$sources" | sudo tee -a /etc/apt/sources.list
+	sudo apt-get update
+	sudo apt-get install -y --no-install-recommends clang-15
+fi
+

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -5,33 +5,31 @@ on:
     paths-ignore:
     - '.github/workflows/**'
     - '!.github/workflows/ubuntu.yml'
+    - '!.github/workflows/install-clang.sh'
   pull_request:
     paths-ignore:
     - '.github/workflows/**'
     - '!.github/workflows/ubuntu.yml'
+    - '!.github/workflows/install-clang.sh'
 
 env:
   CFLAGS: -Wall -Werror
 
 jobs:
-  clang-15:
-    runs-on: ubuntu-22.04
+  test:
+    strategy:
+      matrix:
+        compiler: [clang-15, gcc]
+        os: [ubuntu-22.04, ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
     env:
-      CC: /usr/bin/clang-15
-      CXX: /usr/bin/clang++-15
-      ASM: /usr/bin/clang-15
+      CC: ${{ matrix.compiler }}
+      DISTRO: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - name: install toolchain
-      run: |
-        if [[ -e $CC && -e $CXX ]]; then \
-          echo "clang-15 already presents in the image"; \
-        else \
-          echo "clang-15 missed in the image, installing from llvm"; \
-          echo "deb [trusted=yes] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" | sudo tee -a /etc/apt/sources.list; \
-          sudo apt-get update; \
-          sudo apt-get install -y --no-install-recommends clang-15; \
-        fi
+      if: ${{ (matrix.compiler == 'clang-15') }}
+      run: .github/workflows/install-clang.sh 15
     - name: install prerequisites
       run: |
         sudo apt-get update
@@ -45,6 +43,8 @@ jobs:
           libxext-dev \
           libxfixes-dev \
           libwayland-dev
+    - name: print compiler version
+      run: ${{ matrix.compiler }} --version
     - name: configure
       run: ./autogen.sh --prefix=/usr
     - name: build
@@ -53,56 +53,3 @@ jobs:
       run: make check
     - name: install
       run: sudo make install
-
-  ubuntu-22-04:
-    runs-on: ubuntu-22.04
-    steps:
-    - uses: actions/checkout@v3
-    - name: install prerequisites
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          libdrm-dev \
-          libegl1-mesa-dev \
-          libgl1-mesa-dev \
-          libx11-dev \
-          libx11-xcb-dev \
-          libxcb-dri3-dev \
-          libxext-dev \
-          libxfixes-dev \
-          libwayland-dev
-    - name: configure
-      run: ./autogen.sh --prefix=/usr
-    - name: build
-      run: make
-    - name: check
-      run: make check
-    - name: install
-      run: sudo make install
-
-  ubuntu-20-04:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v3
-    - name: install prerequisites
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          libdrm-dev \
-          libegl1-mesa-dev \
-          libgl1-mesa-dev \
-          libx11-dev \
-          libx11-xcb-dev \
-          libxcb-dri3-dev \
-          libxext-dev \
-          libxfixes-dev \
-          libwayland-dev
-    - name: configure
-      run: ./autogen.sh --prefix=/usr
-    - name: build
-      run: make
-    - name: check
-      run: make check
-    - name: install
-      run: sudo make install
-


### PR DESCRIPTION
Currently we have a bit of duplication in the CI. Instead we can use a simple matrix and also gain ubuntu 20.04 + clang-15 combination.

To keep things sane, we've moved the clang-15 install into a standalone script.

... as promised in https://github.com/intel/libva/pull/638#issuecomment-1273771424

/cc @dvrogozh 