### PR TITLE
ci: add meson permutation in the Ubuntu builds 

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -49,7 +49,5 @@ jobs:
       run: ./autogen.sh --prefix=/usr
     - name: build
       run: make
-    - name: check
-      run: make check
     - name: install
       run: sudo make install

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         compiler: [clang-15, gcc]
         os: [ubuntu-22.04, ubuntu-20.04]
+        build: [meson, autotools]
     runs-on: ${{ matrix.os }}
     env:
       CC: ${{ matrix.compiler }}
@@ -42,12 +43,26 @@ jobs:
           libxcb-dri3-dev \
           libxext-dev \
           libxfixes-dev \
-          libwayland-dev
+          libwayland-dev \
+          meson
     - name: print compiler version
       run: ${{ matrix.compiler }} --version
+    - name: meson setup
+      if: ${{ (matrix.build == 'meson') }}
+      run: meson setup ./builddir --prefix=/usr
+    - name: meson compile
+      if: ${{ (matrix.build == 'meson') }}
+      run: meson compile -C ./builddir || ninja -C ./builddir
+    - name: meson install
+      if: ${{ (matrix.build == 'meson') }}
+      run: sudo meson install -C ./builddir
+
     - name: configure
+      if: ${{ (matrix.build == 'autotools') }}
       run: ./autogen.sh --prefix=/usr
     - name: build
+      if: ${{ (matrix.build == 'autotools') }}
       run: make
     - name: install
+      if: ${{ (matrix.build == 'autotools') }}
       run: sudo make install


### PR DESCRIPTION
A number of Linux distributions have switched to the meson build. In
particular - Arch, Fedora, Gentoo and more are to follow in due time.

Even the libva builds that Chrome uses (aka instrumented libraries) is
using meson (on top of Ubuntu, currently aiming at switching to Focal).

Note: `meson compile` was introduced with meson 0.54, where we use 0.53
since that's available in Ubuntu 20.04. As such we fallback to calling
ninja directly