### PR TITLE
ci: pretty and consistent messages, restrict better

### DIFF
--- a/.cvsignore
+++ b/.cvsignore
@@ -1,3 +1,0 @@
-*~
-Makefile.in
-Makefile

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -22,5 +22,6 @@ jobs:
           pkg install -y meson pkgconf libdrm libXext libXfixes wayland
           pkg install -y -x '^mesa($|-libs)'
         run: |
-          meson _build
+          meson setup _build
           meson compile -C _build
+          meson install -C _build

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -14,8 +14,9 @@ jobs:
   freebsd:
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v3
-    - name: test
+    - name: 'Checkout'
+      uses: actions/checkout@v3
+    - name: 'Install prerequisites and build'
       uses: vmactions/freebsd-vm@v0
       with:
         prepare: |

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,14 +1,6 @@
 name: freebsd
 
-on:
-  push:
-    paths-ignore:
-    - '.github/workflows/**'
-    - '!.github/workflows/freebsd.yml'
-  pull_request:
-    paths-ignore:
-    - '.github/workflows/**'
-    - '!.github/workflows/freebsd.yml'
+on: [push, pull_request]
 
 jobs:
   freebsd:

--- a/.github/workflows/install-clang.sh
+++ b/.github/workflows/install-clang.sh
@@ -27,6 +27,6 @@ if ! which $CC >/dev/null 2>&1; then
 	echo "clang-$llvm_version missed in the image, installing from llvm"
 	echo "$sources" | sudo tee -a /etc/apt/sources.list
 	sudo apt-get update
-	sudo apt-get install -y --no-install-recommends clang-15
+	sudo apt-get install -y --no-install-recommends clang-$llvm_version
 fi
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -16,14 +16,13 @@ jobs:
   style-check:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-    - name: install prerequisites
+    - name: 'Checkout'
+      uses: actions/checkout@v3
+    - name: 'Install prerequisites'
       run: |
         sudo apt-get update
         sudo apt-get install -y \
           astyle
-    - name: style unify
-      run: ./style_unify
-    - name: check
-      run:  .github/workflows/style.sh
+    - name: 'Check for style changes'
+      run: ./style_unify && .github/workflows/style.sh
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,16 +1,6 @@
 name: style
 
-on:
-  push:
-    paths-ignore:
-    - '.github/workflows/**'
-    - '!.github/workflows/style.yml'
-    - '!.github/workflows/style.sh'
-  pull_request:
-    paths-ignore:
-    - '.github/workflows/**'
-    - '!.github/workflows/style.yml'
-    - '!.github/workflows/style.sh'
+on: [push, pull_request]
 
 jobs:
   style-check:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,11 +27,12 @@ jobs:
       CC: ${{ matrix.compiler }}
       DISTRO: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
-    - name: install toolchain
+    - name: 'Checkout'
+      uses: actions/checkout@v3
+    - name: 'Install toolchain'
       if: ${{ (matrix.compiler == 'clang-15') }}
       run: .github/workflows/install-clang.sh 15
-    - name: install prerequisites
+    - name: 'Install prerequisites'
       run: |
         sudo apt-get update
         sudo apt-get install -y \
@@ -45,24 +46,24 @@ jobs:
           libxfixes-dev \
           libwayland-dev \
           meson
-    - name: print compiler version
+    - name: 'Print compiler version'
       run: ${{ matrix.compiler }} --version
-    - name: meson setup
+    - name: 'Configure (meson)'
       if: ${{ (matrix.build == 'meson') }}
       run: meson setup ./builddir --prefix=/usr
-    - name: meson compile
+    - name: 'Build (meson)'
       if: ${{ (matrix.build == 'meson') }}
       run: meson compile -C ./builddir || ninja -C ./builddir
-    - name: meson install
+    - name: 'Install (meson)'
       if: ${{ (matrix.build == 'meson') }}
       run: sudo meson install -C ./builddir
 
-    - name: configure
+    - name: 'Configure (autotools)'
       if: ${{ (matrix.build == 'autotools') }}
       run: ./autogen.sh --prefix=/usr
-    - name: build
+    - name: 'Build (autotools)'
       if: ${{ (matrix.build == 'autotools') }}
       run: make
-    - name: install
+    - name: 'Build and Install (autotools)'
       if: ${{ (matrix.build == 'autotools') }}
       run: sudo make install

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,16 +1,6 @@
 name: ubuntu
 
-on:
-  push:
-    paths-ignore:
-    - '.github/workflows/**'
-    - '!.github/workflows/ubuntu.yml'
-    - '!.github/workflows/install-clang.sh'
-  pull_request:
-    paths-ignore:
-    - '.github/workflows/**'
-    - '!.github/workflows/ubuntu.yml'
-    - '!.github/workflows/install-clang.sh'
+on: [push, pull_request]
 
 env:
   CFLAGS: -Wall -Werror

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,18 +22,22 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - name: Install Meson
+    - name: 'Install Meson'
       run: pip install meson
-    - name: Enter DevShell
+    - name: 'Enter DevShell'
       run: '.github\workflows\EnterDevShell.ps1 ${{ inputs.architecture }}'
       shell: pwsh
-    - name: Configure with meson
-      run: meson build
-    - name: Build and Install
-      run: ninja -C build install
+    - name: 'Configure with meson'
+      run: meson setup _build
+    - name: 'Build'
+      run: meson compile -C _build
+    - name: 'Install'
+      run: meson install -C _build
 
   windows-mingw:
     runs-on: windows-2022
+    env:
+      CC: gcc
     defaults:
       run:
         shell: msys2 {0}
@@ -48,10 +52,12 @@ jobs:
         pacboy: >-
           toolchain:p
           meson:p
-    - name: Enter DevShell
+    - name: 'Enter DevShell'
       run: '.github\workflows\EnterDevShell.ps1 ${{ inputs.architecture }}'
       shell: pwsh
-    - name: Configure with meson
-      run: CC=gcc meson build
-    - name: Build and Install
-      run: CC=gcc ninja -C build install
+    - name: 'Configure'
+      run: meson setup _build
+    - name: 'Build'
+      run: meson compile -C _build
+    - name: 'Install'
+      run: meson install -C _build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,16 +1,6 @@
 name: windows
 
-on:
-  push:
-    paths-ignore:
-    - '.github/workflows/**'
-    - '!.github/workflows/windows.yml'
-    - '!.github/workflows/EnterDevShell.ps1'
-  pull_request:
-    paths-ignore:
-    - '.github/workflows/**'
-    - '!.github/workflows/windows.yml'
-    - '!.github/workflows/EnterDevShell.ps1'
+on: [push, pull_request]
 
 jobs:
   windows-msvc:


### PR DESCRIPTION
This is a mixed bag of CI bits:
 - use consistent conventions - step names, commands - across the workflows
 - honour the version passed to install-clang.sh
 - restrict the scope of the workflows - before they would trigger on "README.md" "doc/*" and others
 
 The last commit adds a bit of duplication. If anyone has ideas how to avoid it, I'm all ears.