### PR TITLE
ci: auto deploy the GitHub pages/docs on releases

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -1,0 +1,57 @@
+name: Deploy Docs to GitHub
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-22.04
+    steps:
+    - name: 'Checkout'
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: 'Get latest tag'
+      run: echo "GIT_LATEST_TAG=$(git tag | grep '^[0-9]\+\.[0-9]\+\?\.[0-9]\+\?$' | sort -V -r | head -n1)" >> $GITHUB_ENV
+
+    - name: 'Variables'
+      run: |
+        echo $GITHUB_REF_NAME
+        echo $GIT_LATEST_TAG
+
+    - name: 'Install prerequisites'
+      if: github.ref_name == env.GIT_LATEST_TAG
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libdrm-dev \
+          doxygen \
+          meson \
+    - name: 'Build the Docs'
+      if: github.ref_name == env.GIT_LATEST_TAG
+      run: meson setup _build -D enable_docs=true && meson compile -C _build
+
+    - name: 'Upload the artifacts'
+      if: github.ref_name == env.GIT_LATEST_TAG
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: "_build/doc/html-out"
+
+    - name: 'Deploy to GitHub Pages'
+      if: github.ref_name == env.GIT_LATEST_TAG
+      id: deployment
+      uses: actions/deploy-pages@v1

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -34,7 +34,7 @@ foreach h : libva_headers_doc
 endforeach
 
 config = configuration_data()
-config.set('PACKAGE_VERSION', meson.project_version())
+config.set('PACKAGE_VERSION', libva_version)
 config.set('VA_HEADER_DIR', headerdir)
 config.set('VA_HEADER_FILES', headers)
 config.set('VA_HTML_FOOTER', footer)

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -13,6 +13,7 @@ libva_headers_doc = [
   'va_enc_hevc.h',
   'va_enc_vp8.h',
   'va_enc_vp9.h',
+  'va_enc_av1.h',
   'va_fei.h',
   'va_fei_h264.h',
   'va_fei_hevc.h',


### PR DESCRIPTION
This adds a workflow, that triggers on GitHub releases, building/deploying the docs only when needed.

For example:
 - release 2.17.0 - deployed
 - release 2.18.0  - deployed
 - release 2.17.1 - skipped

Notes:
 - with this merged, the `gh-pages` branch can be removed ... we should also remove `va_win` and `revert-583-HierarchyInfo`
 - this requires two small changes in the project settings
    - Settings -> Pages -> Build and deployment -> Source -> GitHub Actions
    - Settings -> Environment -> github-pages -> Add deployment branch rule -> Add "[0-9].[0-9][0-9].[0-9]" -> Add rule

This MR builds upon and supersedes https://github.com/intel/libva/pull/642. Notable changes:
 - NOTE: fetches the complete history, without this the tag sorting/selection is broken
 - uses the official github actions
 - builds the minimal set of libva and only as needed
 - pretty UI and URL in the Action

