### PR TITLE
ci: add build docs test and trivial fixes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,27 @@
+name: docs
+
+on:
+  push:
+    paths-ignore:
+    - '.github/workflows/**'
+    - '!.github/workflows/docs.yml'
+  pull_request:
+    paths-ignore:
+    - '.github/workflows/**'
+    - '!.github/workflows/docs.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: install prerequisites
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          doxygen \
+          libdrm-dev \
+          meson
+    - name: build the docs
+      run: meson setup _build -D enable_docs=true && meson compile -C _build
+

--- a/va/va.h
+++ b/va/va.h
@@ -401,6 +401,7 @@ typedef int VAStatus;   /** Return status type from functions */
  */
 const char *vaErrorStr(VAStatus error_status);
 
+/** \brief Structure to describe rectangle. */
 typedef struct _VARectangle {
     int16_t x;
     int16_t y;
@@ -410,12 +411,18 @@ typedef struct _VARectangle {
 
 /** \brief Generic motion vector data structure. */
 typedef struct _VAMotionVector {
-    /** \mv0[0]: horizontal motion vector for past reference */
-    /** \mv0[1]: vertical motion vector for past reference */
-    /** \mv1[0]: horizontal motion vector for future reference */
-    /** \mv1[1]: vertical motion vector for future reference */
-    int16_t  mv0[2];  /* past reference */
-    int16_t  mv1[2];  /* future reference */
+    /** \brief Past reference
+     *
+     * - \c [0]: horizontal motion vector for past reference
+     * - \c [1]: vertical motion vector for past reference
+     */
+    int16_t  mv0[2];
+    /** \brief Future reference
+     *
+     * - \c [0]: horizontal motion vector for future reference
+     * - \c [1]: vertical motion vector for future reference
+     */
+    int16_t  mv1[2];
 } VAMotionVector;
 
 /** Type of a message callback, used for both error and info log. */
@@ -1771,7 +1778,7 @@ typedef struct _VASurfaceAttribExternalBuffers {
  * \brief Queries surface attributes for the supplied config.
  *
  * This function queries for all supported attributes for the
- * supplied VA @config. In particular, if the underlying hardware
+ * supplied VA \c config. In particular, if the underlying hardware
  * supports the creation of VA surfaces in various formats, then
  * this function will enumerate all pixel formats that are supported.
  *

--- a/va/va_dec_vp8.h
+++ b/va/va_dec_vp8.h
@@ -23,7 +23,7 @@
  */
 
 /**
- * \file va_dec_vp.h
+ * \file va_dec_vp8.h
  * \brief VP8 decoding API
  *
  * This file contains the \ref api_dec_vp8 "VP8 decoding API".

--- a/va/va_fei.h
+++ b/va/va_fei.h
@@ -161,6 +161,8 @@ typedef struct _VAStatsStatisticsParameter {
     VABufferID      qp;
 } VAStatsStatisticsParameter;
 
+/**@}*/
+
 #ifdef __cplusplus
 }
 #endif

--- a/va/va_fei_h264.h
+++ b/va/va_fei_h264.h
@@ -496,6 +496,7 @@ typedef struct _VAStatsStatisticsH264 {
     uint32_t    pixel_average_8x8[4];
 } VAStatsStatisticsH264;  // 64 bytes
 
+/**@}*/
 
 #ifdef __cplusplus
 }

--- a/va/va_fei_hevc.h
+++ b/va/va_fei_hevc.h
@@ -243,6 +243,9 @@ typedef struct _VAEncFEIDistortionHevc {
     /** only when colocated_ctb_distortion in VAEncMiscParameterFEIFrameControlHEVC is set */
     uint32_t    colocated_ctb_distortion;
 } VAEncFEIDistortionHevc;
+
+/**@}*/
+
 #ifdef __cplusplus
 }
 #endif

--- a/va/va_vpp.h
+++ b/va/va_vpp.h
@@ -480,14 +480,14 @@ typedef struct _VABlendState {
     /**
      * \brief Global alpha value.
      *
-     * Valid if \flags has VA_BLEND_GLOBAL_ALPHA.
+     * Valid if \ref flags has VA_BLEND_GLOBAL_ALPHA.
      * Valid range is 0.0 to 1.0 inclusive.
      */
     float               global_alpha;
     /**
      * \brief Minimum luma value.
      *
-     * Valid if \flags has VA_BLEND_LUMA_KEY.
+     * Valid if \ref flags has VA_BLEND_LUMA_KEY.
      * Valid range is 0.0 to 1.0 inclusive.
      * \ref min_luma shall be set to a sensible value lower than \ref max_luma.
      */
@@ -495,7 +495,7 @@ typedef struct _VABlendState {
     /**
      * \brief Maximum luma value.
      *
-     * Valid if \flags has VA_BLEND_LUMA_KEY.
+     * Valid if \ref flags has VA_BLEND_LUMA_KEY.
      * Valid range is 0.0 to 1.0 inclusive.
      * \ref max_luma shall be set to a sensible value larger than \ref min_luma.
      */

--- a/va/va_vpp.h
+++ b/va/va_vpp.h
@@ -1042,7 +1042,7 @@ typedef struct _VAProcPipelineParameterBuffer {
      */
     const VABlendState *blend_state;
     /**
-     * \bried mirroring state. See "Mirroring directions".
+     * \brief mirroring state. See "Mirroring directions".
      *
      * Mirroring of an image can be performed either along the
      * horizontal or vertical axis. It is assumed that the rotation


### PR DESCRIPTION
Support of the libva docs is not in a good shape. Last update to github pages corresponds to 2.13 release while we are at 2.17 already (in master). Docs have a number of markup issues with some syntax errors and broken cross links. Taking the first step on the journey to fix, let's add ci to at least regularly build docs path and be able to see the associated log. Addressing issues should be a next step. This PR just adds ci and fixes few trivial syntax errors.