### PR TITLE
Rewrite driver registry query and fix some bugs/leaks/inefficiencies

### DIFF
--- a/va/compat_win32.h
+++ b/va/compat_win32.h
@@ -128,18 +128,14 @@ inline int gettimeofday(struct timeval *tv, struct timezone* tz)
 //
 typedef UINT D3DKMT_HANDLE;
 
-typedef struct _D3DKMT_ADAPTERINFO {
-    D3DKMT_HANDLE       hAdapter;
-    LUID                AdapterLuid;
-    ULONG               NumOfSources;
-    BOOL                bPrecisePresentRegionsPreferred;
-} D3DKMT_ADAPTERINFO;
+typedef struct _D3DKMT_CLOSEADAPTER {
+    D3DKMT_HANDLE   hAdapter;   // in: adapter handle
+} D3DKMT_CLOSEADAPTER;
 
-typedef struct _D3DKMT_ENUMADAPTERS2 {
-    ULONG                 NumAdapters;           // in/out: On input, the count of the pAdapters array buffer.  On output, the number of adapters enumerated.
-    D3DKMT_ADAPTERINFO*   pAdapters;             // out: Array of enumerated adapters containing NumAdapters elements
-} D3DKMT_ENUMADAPTERS2;
-
+typedef struct _D3DKMT_OPENADAPTERFROMLUID {
+    LUID            AdapterLuid;
+    D3DKMT_HANDLE   hAdapter;
+} D3DKMT_OPENADAPTERFROMLUID;
 
 typedef enum _KMTQUERYADAPTERINFOTYPE {
     KMTQAITYPE_QUERYREGISTRY           = 48,
@@ -188,7 +184,8 @@ typedef struct _D3DDDI_QUERYREGISTRY_INFO {
     };
 } D3DDDI_QUERYREGISTRY_INFO;
 
-typedef _Check_return_ NTSTATUS(APIENTRY *PFND3DKMT_ENUMADAPTERS2)(_Inout_ CONST D3DKMT_ENUMADAPTERS2*);
+typedef _Check_return_ NTSTATUS(APIENTRY *PFND3DKMT_CLOSEADAPTER)(_In_ CONST D3DKMT_CLOSEADAPTER*);
+typedef _Check_return_ NTSTATUS(APIENTRY *PFND3DKMT_OPENADAPTERFROMLUID)(_Inout_ D3DKMT_OPENADAPTERFROMLUID*);
 typedef _Check_return_ NTSTATUS(APIENTRY *PFND3DKMT_QUERYADAPTERINFO)(_Inout_ CONST D3DKMT_QUERYADAPTERINFO*);
 
 #endif

--- a/va/win32/va_win32.c
+++ b/va/win32/va_win32.c
@@ -277,6 +277,10 @@ VADisplay vaGetDisplayWin32(
     pDisplayContext->vaGetDriverNameByIndex = va_DisplayContextGetDriverNameByIndex;
     pDisplayContext->vaGetNumCandidates = va_DisplayContextGetNumCandidates;
     pDisplayContext->opaque = calloc(1, sizeof(VADisplayContextWin32));
+    if (!pDisplayContext->opaque) {
+        va_DisplayContextDestroy(pDisplayContext);
+        return NULL;
+    }
 
     VADisplayContextWin32* pWin32Ctx = (VADisplayContextWin32*) pDisplayContext->opaque;
     if (adapter_luid) {

--- a/va/win32/va_win32.c
+++ b/va/win32/va_win32.c
@@ -35,20 +35,6 @@
  * does not have a registered VA driver
 */
 const char VAAPI_DEFAULT_DRIVER_NAME[] = "vaon12";
-const char VAAPI_REG_SUB_KEY[] = "VAAPIDriverName";
-const char VAAPI_REG_SUB_KEY_WOW[] = "VAAPIDriverNameWow";
-
-inline const char* GetVAAPIRegKeyName()
-{
-#ifdef _WIN64
-    return VAAPI_REG_SUB_KEY;
-#else
-    BOOL is_wow64 = FALSE;
-    if (IsWow64Process(GetCurrentProcess(), &is_wow64) && is_wow64)
-        return VAAPI_REG_SUB_KEY_WOW;
-    return VAAPI_REG_SUB_KEY;
-#endif
-}
 
 typedef struct _VADisplayContextWin32 {
     LUID adapter_luid;
@@ -58,136 +44,73 @@ typedef struct _VADisplayContextWin32 {
 
 static bool TryLoadDriverNameFromRegistry(const LUID* adapter_luid, VADisplayContextWin32* pWin32Ctx)
 {
-    if (!adapter_luid)
+    HMODULE hGdi32 = LoadLibraryA("gdi32.dll");
+    if (!hGdi32)
         return false;
 
-    /* Get handle to GDI Runtime */
-    HMODULE h = LoadLibrary("gdi32.dll");
-    if (h == NULL)
-        return false;
-
+    D3DKMT_OPENADAPTERFROMLUID OpenArgs = { .AdapterLuid = *adapter_luid };
+    D3DDDI_QUERYREGISTRY_INFO RegistryInfo = {
+        .QueryType = D3DDDI_QUERYREGISTRY_ADAPTERKEY,
+        .QueryFlags.TranslatePath = true,
+        .ValueName = L"VAAPIDriverName",
+        .ValueType = REG_SZ,
+    };
+    D3DDDI_QUERYREGISTRY_INFO *pRegistryInfo = &RegistryInfo;
+#ifndef _WIN64
+    BOOL isWowProcess = false;
+    if (IsWow64Process(GetCurrentProcess(), &isWowProcess) && isWowProcess)
+        wcscpy(RegistryInfo.ValueName, "VAAPIDriverNameWow");
+#endif
+    D3DKMT_QUERYADAPTERINFO QAI = {
+        .Type = KMTQAITYPE_QUERYREGISTRY,
+        .pPrivateDriverData = &RegistryInfo,
+        .PrivateDriverDataSize = sizeof(RegistryInfo),
+    };
     bool ret = false;
-    int result = 0;
-    /* Check the OS version */
-    if (GetProcAddress(h, "D3DKMTSubmitPresentBltToHwQueue")) {
-        D3DKMT_ENUMADAPTERS2 EnumAdapters;
-        NTSTATUS status = STATUS_SUCCESS;
 
-        EnumAdapters.NumAdapters = 0;
-        EnumAdapters.pAdapters = NULL;
-        PFND3DKMT_ENUMADAPTERS2 pEnumAdapters2 = (PFND3DKMT_ENUMADAPTERS2)GetProcAddress(h, "D3DKMTEnumAdapters2");
-        if (!pEnumAdapters2) {
-            fprintf(stderr, "VA_Win32: GetProcAddress failed for D3DKMTEnumAdapters2\n");
-            goto out;
-        }
-        PFND3DKMT_QUERYADAPTERINFO pQueryAdapterInfo = (PFND3DKMT_QUERYADAPTERINFO)GetProcAddress(h, "D3DKMTQueryAdapterInfo");
-        if (!pQueryAdapterInfo) {
-            fprintf(stderr, "VA_Win32: GetProcAddress failed for D3DKMTQueryAdapterInfo\n");
-            goto out;
-        }
-        while (1) {
-            EnumAdapters.NumAdapters = 0;
-            EnumAdapters.pAdapters = NULL;
-            status = pEnumAdapters2(&EnumAdapters);
-            if (status == STATUS_BUFFER_TOO_SMALL) {
-                /* Number of Adapters increased between calls, retry; */
-                continue;
-            } else if (!NT_SUCCESS(status)) {
-                fprintf(stderr, "VA_Win32: D3DKMTEnumAdapters2 status != SUCCESS\n");
-                goto out;
-            }
-            break;
-        }
-        EnumAdapters.pAdapters = malloc(sizeof(*EnumAdapters.pAdapters) * (EnumAdapters.NumAdapters));
-        if (EnumAdapters.pAdapters == NULL) {
-            fprintf(stderr, "VA_Win32: Allocation failure for adapters buffer\n");
-            goto out;
-        }
-        status = pEnumAdapters2(&EnumAdapters);
-        if (!NT_SUCCESS(status)) {
-            fprintf(stderr, "VA_Win32: D3DKMTEnumAdapters2 status != SUCCESS\n");
-            goto out;
-        }
-        const char* cszVAAPIRegKeyName = GetVAAPIRegKeyName();
-        const int szVAAPIRegKeyName = (int)(strlen(cszVAAPIRegKeyName) + 1) * sizeof(cszVAAPIRegKeyName[0]);
-        for (UINT AdapterIndex = 0; AdapterIndex < EnumAdapters.NumAdapters; AdapterIndex++) {
-            D3DDDI_QUERYREGISTRY_INFO queryArgs = {0};
-            D3DDDI_QUERYREGISTRY_INFO* pQueryArgs = &queryArgs;
-            D3DDDI_QUERYREGISTRY_INFO* pQueryBuffer = NULL;
-            queryArgs.QueryType = D3DDDI_QUERYREGISTRY_ADAPTERKEY;
-            queryArgs.QueryFlags.TranslatePath = TRUE;
-            queryArgs.ValueType = REG_SZ;
-            result = MultiByteToWideChar(
-                         CP_ACP,
-                         0,
-                         cszVAAPIRegKeyName,
-                         szVAAPIRegKeyName,
-                         queryArgs.ValueName,
-                         ARRAYSIZE(queryArgs.ValueName));
-            if (!result) {
-                fprintf(stderr, "VA_Win32: MultiByteToWideChar status != SUCCESS\n");
-                continue;
-            }
-            D3DKMT_QUERYADAPTERINFO queryAdapterInfo = {0};
-            queryAdapterInfo.hAdapter = EnumAdapters.pAdapters[AdapterIndex].hAdapter;
-            queryAdapterInfo.Type = KMTQAITYPE_QUERYREGISTRY;
-            queryAdapterInfo.pPrivateDriverData = &queryArgs;
-            queryAdapterInfo.PrivateDriverDataSize = sizeof(queryArgs);
-            status = pQueryAdapterInfo(&queryAdapterInfo);
-            if (!NT_SUCCESS(status)) {
-                /* Try a different value type.  Some vendors write the key as a multi-string type. */
-                queryArgs.ValueType = REG_MULTI_SZ;
-                status = pQueryAdapterInfo(&queryAdapterInfo);
-                if (NT_SUCCESS(status)) {
-                    fprintf(stderr, "VA_Win32: Accepting multi-string registry key type\n");
-                } else {
-                    /* Continue trying to get as much info on each adapter as possible. */
-                    /* It's too late to return FALSE and claim WDDM2_4 enumeration is not available here. */
-                    continue;
-                }
-            }
-            if (NT_SUCCESS(status) && pQueryArgs->Status == D3DDDI_QUERYREGISTRY_STATUS_BUFFER_OVERFLOW) {
-                ULONG queryBufferSize = sizeof(D3DDDI_QUERYREGISTRY_INFO) + queryArgs.OutputValueSize;
-                pQueryBuffer = malloc(queryBufferSize);
-                if (pQueryBuffer == NULL)
-                    continue;
-                memcpy(pQueryBuffer, &queryArgs, sizeof(D3DDDI_QUERYREGISTRY_INFO));
-                queryAdapterInfo.pPrivateDriverData = pQueryBuffer;
-                queryAdapterInfo.PrivateDriverDataSize = queryBufferSize;
-                status = pQueryAdapterInfo(&queryAdapterInfo);
-                pQueryArgs = pQueryBuffer;
-            }
-            if (NT_SUCCESS(status) && pQueryArgs->Status == D3DDDI_QUERYREGISTRY_STATUS_SUCCESS) {
-                wchar_t* pWchar = pQueryArgs->OutputString;
-                memset(pWin32Ctx->registry_driver_name, 0, sizeof(pWin32Ctx->registry_driver_name));
-                size_t len;
-                wcstombs_s(&len, pWin32Ctx->registry_driver_name, sizeof(pWin32Ctx->registry_driver_name), pWchar, sizeof(pWin32Ctx->registry_driver_name));
-                assert(len <= (sizeof(pWin32Ctx->registry_driver_name) - 1));
-                if (0 == memcmp(adapter_luid, &EnumAdapters.pAdapters[AdapterIndex].AdapterLuid, sizeof(EnumAdapters.pAdapters[AdapterIndex].AdapterLuid))) {
-                    ret = true;
-                    /* Found the adapter we wanted, finish iteration. Associated driver string is loaded in pWin32Ctx->registry_driver_name */
-                    /* VAAPI needs the stripped driver filename, without the absolute path or the extension. */
+    PFND3DKMT_OPENADAPTERFROMLUID pfnOpenAdapterFromLuid = (PFND3DKMT_OPENADAPTERFROMLUID)GetProcAddress(hGdi32, "D3DKMTOpenAdapterFromLuid");
+    PFND3DKMT_CLOSEADAPTER pfnCloseAdapter = (PFND3DKMT_CLOSEADAPTER)GetProcAddress(hGdi32, "D3DKMTCloseAdapter");
+    PFND3DKMT_QUERYADAPTERINFO pfnQueryAdapterInfo = (PFND3DKMT_QUERYADAPTERINFO)GetProcAddress(hGdi32, "D3DKMTQueryAdapterInfo");
+    if (!pfnOpenAdapterFromLuid || !pfnCloseAdapter || !pfnQueryAdapterInfo)
+        goto cleanup;
 
-                    /* Zero-out the extension section with null terminators if present */
-                    char* pExtPosition = strstr(pWin32Ctx->registry_driver_name, ".dll");
-                    if (pExtPosition)
-                        memset(pExtPosition, '\0', 4 /*size of the 4 chars of .dll*/);
+    if (!NT_SUCCESS(pfnOpenAdapterFromLuid(&OpenArgs)))
+        goto cleanup;
 
-                    free(pQueryBuffer);
-                    goto out;
-                }
-            } else if (status == (NTSTATUS)STATUS_INVALID_PARAMETER) {
-                free(pQueryBuffer);
-                goto out;
-            }
-            free(pQueryBuffer);
-        }
-out:
-        free(EnumAdapters.pAdapters);
+    QAI.hAdapter = OpenArgs.hAdapter;
+    if (!NT_SUCCESS(pfnQueryAdapterInfo(&QAI)) ||
+        pRegistryInfo->Status != D3DDDI_QUERYREGISTRY_STATUS_BUFFER_OVERFLOW)
+        goto cleanup;
+
+    size_t RegistryInfoSize = sizeof(RegistryInfo) + RegistryInfo.OutputValueSize;
+    pRegistryInfo = malloc(RegistryInfoSize);
+    if (!pRegistryInfo)
+        goto cleanup;
+
+    memcpy(pRegistryInfo, &RegistryInfo, sizeof(RegistryInfo));
+    QAI.pPrivateDriverData = pRegistryInfo;
+    QAI.PrivateDriverDataSize = RegistryInfoSize;
+    if (!NT_SUCCESS(pfnQueryAdapterInfo(&QAI)) ||
+        pRegistryInfo->Status != D3DDDI_QUERYREGISTRY_STATUS_SUCCESS)
+        goto cleanup;
+
+    if (!WideCharToMultiByte(CP_ACP, 0, pRegistryInfo->OutputString,
+                             RegistryInfo.OutputValueSize / sizeof(wchar_t),
+                             pWin32Ctx->registry_driver_name,
+                             sizeof(pWin32Ctx->registry_driver_name),
+                             NULL, NULL))
+        goto cleanup;
+
+    ret = true;
+
+cleanup:
+    if (pRegistryInfo && pRegistryInfo != &RegistryInfo)
+        free(pRegistryInfo);
+    if (pfnCloseAdapter && OpenArgs.hAdapter) {
+        D3DKMT_CLOSEADAPTER Close = { OpenArgs.hAdapter };
+        pfnCloseAdapter(&Close);
     }
-
-    FreeLibrary(h);
-
+    FreeLibrary(hGdi32);
     return ret;
 }
 


### PR DESCRIPTION
Instead of enumerating all adapters, just open the one we want by LUID. Also close the adapter, and consolidate error handling.