### PR TITLE
ci: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Add a dependabot CI, which will track when any of our CI actions become out of date. When so a PR will be opened automatically by the bot.

Aka automate changes like the following amongst others:

d1f80cb ("ci: switch checkout action from @v2 to @v3")
7afc9ae ("ci: switch python action from @v2 to @v4")

---

See the official documentation for more details and setting up the repository

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

/cc @dvrogozh 