### PR TITLE
Missing declarations

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -75,6 +75,15 @@ configinc = include_directories('.')
 cc = meson.get_compiler('c')
 dl_dep = cc.find_library('dl', required : false)
 
+if cc.get_argument_syntax() == 'gcc'
+  add_project_arguments(
+    cc.get_supported_arguments([
+      '-Werror=missing-prototypes',
+    ]),
+    language: ['c'],
+  )
+endif
+
 WITH_DRM = not get_option('disable_drm') and (host_machine.system() != 'windows')
 libdrm_dep = dependency('libdrm', version : '>= 2.4.60', required : (host_machine.system() != 'windows'))
 

--- a/va/libva.def
+++ b/va/libva.def
@@ -60,8 +60,6 @@ EXPORTS
     vaQuerySurfaceError
     vaSetImagePalette
     vaSetSubpictureChromakey
-    vaLockSurface
-    vaUnlockSurface
     vaCreateMFContext
     vaMFAddContext
     vaMFReleaseContext

--- a/va/libva.def
+++ b/va/libva.def
@@ -60,7 +60,6 @@ EXPORTS
     vaQuerySurfaceError
     vaSetImagePalette
     vaSetSubpictureChromakey
-    vaBufferInfo
     vaLockSurface
     vaUnlockSurface
     vaCreateMFContext

--- a/va/va_compat.c
+++ b/va/va_compat.c
@@ -35,6 +35,16 @@ vaCreateSurfaces_0_32_0(
     int          format,
     int          num_surfaces,
     VASurfaceID *surfaces
+);
+
+VAStatus
+vaCreateSurfaces_0_32_0(
+    VADisplay    dpy,
+    int          width,
+    int          height,
+    int          format,
+    int          num_surfaces,
+    VASurfaceID *surfaces
 )
 {
     return vaCreateSurfaces(dpy, format, width, height, surfaces, num_surfaces,

--- a/va/va_internal.h
+++ b/va/va_internal.h
@@ -50,6 +50,16 @@ VAStatus vaBufferInfo(VADisplay dpy, VAContextID context, VABufferID buf_id,
                       VABufferType *type, unsigned int *size,
                       unsigned int *num_elements);
 
+DLL_HIDDEN
+VAStatus vaLockSurface(VADisplay dpy, VASurfaceID surface, unsigned int *fourcc,
+                       unsigned int *luma_stride, unsigned int *chroma_u_stride,
+                       unsigned int *chroma_v_stride, unsigned int *luma_offset,
+                       unsigned int *chroma_u_offset, unsigned int *chroma_v_offset,
+                       unsigned int *buffer_name, void **buffer);
+
+DLL_HIDDEN
+VAStatus vaUnlockSurface(VADisplay dpy, VASurfaceID surface);
+
 #ifdef __cplusplus
 }
 #endif

--- a/va/va_internal.h
+++ b/va/va_internal.h
@@ -45,6 +45,11 @@ VADisplayContextP va_newDisplayContext(void);
 
 VADriverContextP va_newDriverContext(VADisplayContextP dctx);
 
+DLL_HIDDEN
+VAStatus vaBufferInfo(VADisplay dpy, VAContextID context, VABufferID buf_id,
+                      VABufferType *type, unsigned int *size,
+                      unsigned int *num_elements);
+
 #ifdef __cplusplus
 }
 #endif

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -287,23 +287,6 @@ VAStatus vaBufferInfo(
     unsigned int *num_elements  /* out */
 );
 
-VAStatus vaLockSurface(VADisplay dpy,
-                       VASurfaceID surface,
-                       unsigned int *fourcc, /* following are output argument */
-                       unsigned int *luma_stride,
-                       unsigned int *chroma_u_stride,
-                       unsigned int *chroma_v_stride,
-                       unsigned int *luma_offset,
-                       unsigned int *chroma_u_offset,
-                       unsigned int *chroma_v_offset,
-                       unsigned int *buffer_name,
-                       void **buffer
-                      );
-
-VAStatus vaUnlockSurface(VADisplay dpy,
-                         VASurfaceID surface
-                        );
-
 static int get_valid_config_idx(
     struct va_trace *pva_trace,
     VAConfigID config_id)

--- a/va/x11/va_dri3.c
+++ b/va/x11/va_dri3.c
@@ -43,6 +43,7 @@
 #include <xf86drm.h>
 
 #include "va_backend.h"
+#include "va_dri3.h"
 #include "va_drmcommon.h"
 #include "drm/va_drm_utils.h"
 


### PR DESCRIPTION
This PR fixes the existing `Wmissing-declarations` and makes it an explicit `Werror=missing...` so we don't get new instances.

About the changes themselves:
 - some (should be) internal functions are annotated with DLL_HIDDEN - search in Arch and Github shows zero users
 - some declarations were pulled - explicitly or via respective headers
 - some unnessesary code (lacking declarations) was removed - was https://github.com/intel/libva/pull/667
 
 /cc @sivileri for the Windows libva.def changes. If MSVC has equivalent toggle, let's add it to meson.build 