### PR TITLE
ci: enable Werror across the build

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -15,6 +15,6 @@ jobs:
           pkg install -y meson pkgconf libdrm libXext libXfixes wayland
           pkg install -y -x '^mesa($|-libs)'
         run: |
-          meson setup _build
+          meson setup _build -D werror=true
           meson compile -C _build
           meson install -C _build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ jobs:
       run: '.github\workflows\EnterDevShell.ps1 ${{ inputs.architecture }}'
       shell: pwsh
     - name: 'Configure with meson'
-      run: meson setup _build
+      run: meson setup _build -D werror=true
     - name: 'Build'
       run: meson compile -C _build
     - name: 'Install'
@@ -46,7 +46,7 @@ jobs:
       run: '.github\workflows\EnterDevShell.ps1 ${{ inputs.architecture }}'
       shell: pwsh
     - name: 'Configure'
-      run: meson setup _build
+      run: meson setup _build -D werror=true
     - name: 'Build'
       run: meson compile -C _build
     - name: 'Install'

--- a/va/win32/va_win32.c
+++ b/va/win32/va_win32.c
@@ -59,7 +59,7 @@ static void LoadDriverNameFromRegistry(VADisplayContextWin32* pWin32Ctx)
 #ifndef _WIN64
     BOOL isWowProcess = false;
     if (IsWow64Process(GetCurrentProcess(), &isWowProcess) && isWowProcess)
-        wcscpy(RegistryInfo.ValueName, "VAAPIDriverNameWow");
+        wcscpy(RegistryInfo.ValueName, L"VAAPIDriverNameWow");
 #endif
     D3DKMT_QUERYADAPTERINFO QAI = {
         .Type = KMTQAITYPE_QUERYREGISTRY,

--- a/va/win32/va_win32.c
+++ b/va/win32/va_win32.c
@@ -107,7 +107,10 @@ cleanup:
         free(pRegistryInfo);
     if (pfnCloseAdapter && OpenArgs.hAdapter) {
         D3DKMT_CLOSEADAPTER Close = { OpenArgs.hAdapter };
-        pfnCloseAdapter(&Close);
+        /* The explicit negation is a no-op, yet required to silence the
+         * Wunused-result warning.
+         */
+        (void) !pfnCloseAdapter(&Close);
     }
     FreeLibrary(hGdi32);
 }


### PR DESCRIPTION
The autotool build(s) already have that, alas the meson ones do not. Use the upstream recommended -D werror=true option.

Signed-off-by: Emil Velikov <emil.l.velikov@gmail.com>