### PR TITLE
Remove reference to non-existent symbol

### DIFF
--- a/va/libva.syms
+++ b/va/libva.syms
@@ -6,6 +6,4 @@ VA_API_0.32.0 {
 VA_API_0.33.0 {
     global:
         vaCreateSurfaces;
-    local:
-        vaCreateSurfaces_0_33_0;
 } VA_API_0.32.0;


### PR DESCRIPTION
This fixes compilation in recent clang versions (tested against https://github.com/llvm/llvm-project/commit/6443c0e) which is apparently stricter with respect to undefined symbols. It appears that this version script reference was never correct.