### PR TITLE
x11: allow disabling DRI3 via LIBVA_DRI3_DISABLE env var

### DIFF
--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -167,14 +167,15 @@ static VAStatus va_DisplayContextGetDriverName(
     char **driver_name, int candidate_index
 )
 {
-    VAStatus vaStatus;
+    VAStatus vaStatus = VA_STATUS_ERROR_UNKNOWN;
 
     if (driver_name)
         *driver_name = NULL;
     else
         return VA_STATUS_ERROR_UNKNOWN;
 
-    vaStatus = va_DRI3_GetDriverName(pDisplayContext, driver_name, candidate_index);
+    if (!getenv("LIBVA_DRI3_DISABLE"))
+        vaStatus = va_DRI3_GetDriverName(pDisplayContext, driver_name, candidate_index);
     if (vaStatus != VA_STATUS_SUCCESS)
         vaStatus = va_DRI2_GetDriverName(pDisplayContext, driver_name, candidate_index);
 #ifdef HAVE_NVCTRL


### PR DESCRIPTION
There are some corner cases where DRI3 does not work correctly. While bug reports are appreciated, this enables users to get back to their machines in meaningful way - aka w/o having to rebuild libva.

---

@dvrogozh @XinfengZhang can we roll a 2.17.1 release with this fix? There is a PR incoming, which will be quiet large and evasive for a bugfix release.

Thanks o/