### PR TITLE
win32: Add vaDisplayIsValid to .def export list

### DIFF
--- a/va/libva.def
+++ b/va/libva.def
@@ -83,3 +83,4 @@ EXPORTS
     vaSetSubpictureImage
     vaStatusStr
     vaSyncSurface2
+    vaDisplayIsValid


### PR DESCRIPTION
vaDisplayIsValid is used by apps calling into VAAPI, and we were missing it from the exports list.

Example of usage on [this app source](https://github.com/FFmpeg/FFmpeg/blob/7158f1e64d9b76afea78537a35c465447df0cff8/libavutil/hwcontext_opencl.c#L778): 

Signed-off-by: Sil Vilerino <sivileri@microsoft.com>