### PR TITLE
win32/loader: Allow backends to provide custom driver search paths

### DIFF
--- a/va/compat_win32.h
+++ b/va/compat_win32.h
@@ -44,6 +44,8 @@ typedef LONG NTSTATUS;
 #define NT_SUCCESS(status) (((NTSTATUS)(status)) >= 0)
 #endif
 
+#define WIN32_DRIVER_NAME_SUFFIX  "_drv_video"
+
 typedef unsigned int __uid_t;
 
 #ifdef _MSC_VER

--- a/va/compat_win32.h
+++ b/va/compat_win32.h
@@ -28,6 +28,11 @@
 #include <winsock.h>
 #include <io.h>
 #include <time.h>
+#include <string.h>
+
+#ifndef _MSC_VER
+#include <libgen.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,6 +52,22 @@ typedef LONG NTSTATUS;
 #define WIN32_DRIVER_NAME_SUFFIX  "_drv_video"
 
 typedef unsigned int __uid_t;
+
+/* Gets driver name without suffix from absolute path */
+inline void va_win32_get_drv_from_path(const char* absolute_path, char* name_no_suffix, size_t name_no_suffix_size)
+{
+#ifdef _MSC_VER
+    _splitpath_s(absolute_path, NULL, 0, NULL, 0, name_no_suffix, name_no_suffix_size, NULL, 0);
+#else
+    strncpy(name_no_suffix, basename(absolute_path), name_no_suffix_size);
+    char* ext_pos = strrchr(name_no_suffix, '.');
+    if (ext_pos != NULL)
+        *ext_pos = '\0';
+#endif
+    char* suffix_pos = strstr(name_no_suffix, WIN32_DRIVER_NAME_SUFFIX);
+    if (suffix_pos)
+        *suffix_pos = '\0';
+}
 
 #ifdef _MSC_VER
 inline char* strtok_r(char *s, const char *delim, char **save_ptr)

--- a/va/va_backend.h
+++ b/va/va_backend.h
@@ -686,6 +686,12 @@ struct VADisplayContext {
         int  candidate_index
     );
 
+    VAStatus(*vaGetDriverSearchPathByIndex)(
+        VADisplayContextP ctx,
+        char **driver_dir,
+        int  candidate_index
+    );
+
     /** \brief Reserved bytes for future use, must be zero */
     unsigned long reserved[30];
 };


### PR DESCRIPTION
When va-win32 loads the registered driver for a given device LUID passed in vaGetDisplayWin32, it's currently treating it merely as a driver name, but the [installable client drivers](https://learn.microsoft.com/en-us/windows-hardware/drivers/display/loading-an-opengl-installable-client-driver) in the registry are required to be absolute paths, so we made some changes to support this:

VA changes:

```
Add a new optional backend function vaGetDriverSearchPathByIndex.
The vaInitialize function will now query the backend (the vaGetDriverSearchPathByIndex not null)
for extra search paths and combine them with the previously usual 
driver_search_path that comes either from LIBVA_DRIVERS_PATH or the VA_DRIVERS_PATH constant.
```

Win32 changes:

```
- Implement vaGetDriverSearchPathByIndex to provide the
search driver absolute path for the registered driver

- Change va_DisplayContextGetDriverNameByIndex to extract the
driver name (minus the drv_video prefix) from the absolute path
in the registry key string.

- Provide a .\ search path for the default vaon12
driver for apps to avoid having to set LIBVA_DRIVERS_PATH
for the default.

```

