### PR TITLE
va: remove dummy isValid() hook

### DIFF
--- a/va/android/va_android.cpp
+++ b/va/android/va_android.cpp
@@ -43,14 +43,6 @@
 #define CHECK_SYMBOL(func) { if (!func) printf("func %s not found\n", #func); return VA_STATUS_ERROR_UNKNOWN; }
 #define DEVICE_NAME "/dev/dri/renderD128"
 
-static int va_DisplayContextIsValid(
-    VADisplayContextP pDisplayContext
-)
-{
-    return (pDisplayContext != NULL &&
-            pDisplayContext->pDriverContext != NULL);
-}
-
 static void va_DisplayContextDestroy(
     VADisplayContextP pDisplayContext
 )
@@ -116,7 +108,6 @@ VADisplay vaGetDisplay(
     if (!pDisplayContext)
         return NULL;
 
-    pDisplayContext->vaIsValid       = va_DisplayContextIsValid;
     pDisplayContext->vaDestroy       = va_DisplayContextDestroy;
     pDisplayContext->vaGetDriverNameByIndex = va_DisplayContextGetDriverNameByIndex;
     pDisplayContext->vaGetNumCandidates = va_DisplayContextGetNumCandidates;

--- a/va/drm/va_drm.c
+++ b/va/drm/va_drm.c
@@ -31,16 +31,6 @@
 #include "va_drm_auth.h"
 #include "va_drm_utils.h"
 
-static int
-va_DisplayContextIsValid(VADisplayContextP pDisplayContext)
-{
-    VADriverContextP const pDriverContext = pDisplayContext->pDriverContext;
-
-    return (pDriverContext &&
-            ((pDriverContext->display_type & VA_DISPLAY_MAJOR_MASK) ==
-             VA_DISPLAY_DRM));
-}
-
 static void
 va_DisplayContextDestroy(VADisplayContextP pDisplayContext)
 {
@@ -113,7 +103,6 @@ vaGetDisplayDRM(int fd)
     if (!pDisplayContext)
         goto error;
 
-    pDisplayContext->vaIsValid       = va_DisplayContextIsValid;
     pDisplayContext->vaDestroy       = va_DisplayContextDestroy;
     pDisplayContext->vaGetNumCandidates = va_DisplayContextGetNumCandidates;
     pDisplayContext->vaGetDriverNameByIndex = va_DisplayContextGetDriverNameByIndex;

--- a/va/va.c
+++ b/va/va.c
@@ -112,7 +112,9 @@ int va_parseConfig(char *env, char *env_value)
 int vaDisplayIsValid(VADisplay dpy)
 {
     VADisplayContextP pDisplayContext = (VADisplayContextP)dpy;
-    return pDisplayContext && (pDisplayContext->vadpy_magic == VA_DISPLAY_MAGIC) && pDisplayContext->vaIsValid(pDisplayContext);
+    return pDisplayContext &&
+           pDisplayContext->vadpy_magic == VA_DISPLAY_MAGIC &&
+           pDisplayContext->pDriverContext;
 }
 
 /*

--- a/va/va_backend.h
+++ b/va/va_backend.h
@@ -654,6 +654,7 @@ struct VADisplayContext {
     VADisplayContextP pNext;
     VADriverContextP pDriverContext;
 
+    /* Deprecated */
     int (*vaIsValid)(
         VADisplayContextP ctx
     );

--- a/va/va_internal.h
+++ b/va/va_internal.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 #define CTX(dpy) (((VADisplayContextP)dpy)->pDriverContext)
-#define CHECK_DISPLAY(dpy) if( !vaDisplayIsValid(dpy) ) { return VA_STATUS_ERROR_INVALID_DISPLAY; }
+#define CHECK_DISPLAY(dpy) if (!vaDisplayIsValid(dpy)) { return VA_STATUS_ERROR_INVALID_DISPLAY; }
 
 DLL_HIDDEN
 void va_errorMessage(VADisplay dpy, const char *msg, ...);

--- a/va/wayland/va_wayland.c
+++ b/va/wayland/va_wayland.c
@@ -54,15 +54,6 @@ va_wayland_error(const char *format, ...)
     va_end(args);
 }
 
-static int
-va_DisplayContextIsValid(VADisplayContextP pDisplayContext)
-{
-    VADriverContextP const pDriverContext = pDisplayContext->pDriverContext;
-
-    return (pDriverContext &&
-            pDriverContext->display_type == VA_DISPLAY_WAYLAND);
-}
-
 static void
 va_DisplayContextDestroy(VADisplayContextP pDisplayContext)
 {
@@ -131,7 +122,6 @@ vaGetDisplayWl(struct wl_display *display)
     if (!pDisplayContext)
         return NULL;
 
-    pDisplayContext->vaIsValid          = va_DisplayContextIsValid;
     pDisplayContext->vaDestroy          = va_DisplayContextDestroy;
     pDisplayContext->vaGetDriverName    = va_DisplayContextGetDriverName;
 

--- a/va/win32/va_win32.c
+++ b/va/win32/va_win32.c
@@ -115,14 +115,6 @@ cleanup:
     FreeLibrary(hGdi32);
 }
 
-static int va_DisplayContextIsValid(
-    VADisplayContextP pDisplayContext
-)
-{
-    return (pDisplayContext != NULL &&
-            pDisplayContext->pDriverContext != NULL);
-}
-
 static void va_DisplayContextDestroy(
     VADisplayContextP pDisplayContext
 )
@@ -196,7 +188,6 @@ VADisplay vaGetDisplayWin32(
     if (!pDisplayContext)
         return NULL;
 
-    pDisplayContext->vaIsValid       = va_DisplayContextIsValid;
     pDisplayContext->vaDestroy       = va_DisplayContextDestroy;
     pDisplayContext->vaGetDriverNameByIndex = va_DisplayContextGetDriverNameByIndex;
     pDisplayContext->vaGetNumCandidates = va_DisplayContextGetNumCandidates;

--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -58,14 +58,6 @@ static const struct driver_name_map g_dri2_driver_name_map[] = {
     { NULL,         NULL }
 };
 
-static int va_DisplayContextIsValid(
-    VADisplayContextP pDisplayContext
-)
-{
-    return (pDisplayContext != NULL &&
-            pDisplayContext->pDriverContext != NULL);
-}
-
 static void va_DisplayContextDestroy(
     VADisplayContextP pDisplayContext
 )
@@ -227,7 +219,6 @@ VADisplay vaGetDisplay(
     if (!pDisplayContext)
         return NULL;
 
-    pDisplayContext->vaIsValid       = va_DisplayContextIsValid;
     pDisplayContext->vaDestroy       = va_DisplayContextDestroy;
     pDisplayContext->vaGetNumCandidates = va_DisplayContextGetNumCandidates;
     pDisplayContext->vaGetDriverNameByIndex = va_DisplayContextGetDriverName;


### PR DESCRIPTION
Bunch of the backends are using a simple
  return pDisplayContext && pDisplayContext->pDriverContext

... where pDisplayContext is always true. A few others are checking the
display_type, which in itself is absolutely useless.

So move the pDriverContext check within core libva and drop the isValid
hook across all winsys libraries.