### PR TITLE
fix: Add libva.def into distribution package

### DIFF
--- a/va/Makefile.am
+++ b/va/Makefile.am
@@ -149,4 +149,5 @@ EXTRA_DIST = \
 	libva.syms		\
 	va_version.h.in		\
 	meson.build		\
+        libva.def               \
 	$(NULL)


### PR DESCRIPTION
libva.def is missing in release tarball

Signed-off-by: Carl Zhang <carl.zhang@intel.com>