### PR TITLE
compat_win32: Add getenv wrapper for WIN32

### DIFF
--- a/va/compat_win32.h
+++ b/va/compat_win32.h
@@ -29,6 +29,11 @@
 #include <io.h>
 #include <time.h>
 
+// Include stdlib.h here to make sure we
+// always replace MSVC getenv definition
+// with the macro / _getenv inline below
+#include <stdlib.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -45,6 +50,15 @@ typedef LONG NTSTATUS;
 #endif
 
 typedef unsigned int __uid_t;
+
+#if _MSC_VER
+#define getenv _getenv
+inline char* _getenv(const char *varname)
+{
+    static char _getenv_buf[32767];
+    return GetEnvironmentVariableA(varname, &_getenv_buf[0], sizeof(_getenv_buf)) ? &_getenv_buf[0] : NULL;
+}
+#endif
 
 #ifdef _MSC_VER
 inline char* strtok_r(char *s, const char *delim, char **save_ptr)


### PR DESCRIPTION
The Windows getenv function reads the snapshot of values of env. variables at va.dll load time, disregarding future putenv calls from the same process.

This causes issues for apps/tests that do putenv/setenv for LIBVA_DRIVER_NAME or LIBVA_DRIVERS_PATH before calling vaInitialize. For example, the vaInitialize_vaTerminate tests in libva-utils test suite.

Fortunately there's a GetEnvironmentVariableA function that does the proper env. var reading taking into account calls to putenv/setenv. Use that function instead for Windows.

https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/getenv-wgetenv?view=msvc-170 https://learn.microsoft.com/en-us/windows/win32/api/processenv/nf-processenv-getenvironmentvariablea

Signed-off-by: Sil Vilerino <sivileri@microsoft.com>