### PR TITLE
x11: use LIBVA_DRI3_DISABLE in GetNumCandidates

### DIFF
--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -195,9 +195,10 @@ static VAStatus va_DisplayContextGetNumCandidates(
     int *num_candidates
 )
 {
-    VAStatus vaStatus;
+    VAStatus vaStatus = VA_STATUS_ERROR_UNKNOWN;
 
-    vaStatus = va_DRI3_GetNumCandidates(pDisplayContext, num_candidates);
+    if (!getenv("LIBVA_DRI3_DISABLE"))
+        vaStatus = va_DRI3_GetNumCandidates(pDisplayContext, num_candidates);
     if (vaStatus != VA_STATUS_SUCCESS)
         vaStatus = va_DRI2_GetNumCandidates(pDisplayContext, num_candidates);
 


### PR DESCRIPTION
As reported by @zhmars, we need to check the override in both code paths.

That's because we get only one candidate, while for Intel GPUs we have 2 drivers - so this might work when the user needs iHD, but will fail if they rely on the older driver.