### PR TITLE
win32: Replace fprintf with proper VA_TRACE function

### DIFF
--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -1096,6 +1096,11 @@ void va_TraceInitialize(
 {
     DPY2TRACE_VIRCTX(dpy);
     TRACE_FUNCNAME(idx);
+
+    const char* vendor_string = vaQueryVendorString(dpy);
+    if (vendor_string)
+        va_TraceMsg(trace_ctx, "==========\tVA-API vendor string: %s\n", vendor_string);
+
     DPY2TRACE_VIRCTX_EXIT(pva_trace);
 }
 

--- a/va/win32/va_win32.c
+++ b/va/win32/va_win32.c
@@ -185,11 +185,13 @@ VADisplay vaGetDisplayWin32(
 
         /* Load the preferred driver name from the driver registry if available */
         LoadDriverNameFromRegistry(pWin32Ctx);
+#ifdef _DEBUG
         if (pWin32Ctx->registry_driver_available_flag) {
             fprintf(stderr, "VA_Win32: Found driver %s in the registry for LUID %ld %ld \n", pWin32Ctx->registry_driver_name, pWin32Ctx->adapter_luid.LowPart, pWin32Ctx->adapter_luid.HighPart);
         } else {
             fprintf(stderr, "VA_Win32: Couldn't find a driver in the registry for LUID %ld %ld. Using default driver: %s \n", pWin32Ctx->adapter_luid.LowPart, pWin32Ctx->adapter_luid.HighPart, VAAPI_DEFAULT_DRIVER_NAME);
         }
+#endif // _DEBUG
     }
 
     pDriverContext = va_newDriverContext(pDisplayContext);


### PR DESCRIPTION
Closes #694 

Tested with environment variable `LIBVA_TRACE=1`.  Trace test when running vainfo:
```
[33752.134567][ctx       none]==========va_TraceInitialize
[33752.134574][ctx       none]==========	VA-API vendor string: Mesa Gallium driver 23.1.0-devel for D3D12 (NVIDIA GeForce RTX 4090)
[33752.134575][ctx       none]=========vaInitialize ret = VA_STATUS_SUCCESS, success (no error) 
[33752.134679][ctx       none]=========vaQueryConfigProfiles ret = VA_STATUS_SUCCESS, success (no error) 
[33752.134696][ctx       none]=========vaQueryConfigEntrypoints ret = VA_STATUS_SUCCESS, success (no error) 
[33752.134700][ctx       none]=========vaQueryConfigEntrypoints ret = VA_STATUS_SUCCESS, success (no error) 
[33752.134704][ctx       none]=========vaQueryConfigEntrypoints ret = VA_STATUS_SUCCESS, success (no error) 
[33752.134712][ctx       none]=========vaQueryConfigEntrypoints ret = VA_STATUS_SUCCESS, success (no error) 
[33752.134716][ctx       none]=========vaQueryConfigEntrypoints ret = VA_STATUS_SUCCESS, success (no error) 
[33752.134719][ctx       none]=========vaQueryConfigEntrypoints ret = VA_STATUS_SUCCESS, success (no error) 
[33752.134720][ctx       none]=========vaQueryConfigEntrypoints ret = VA_STATUS_SUCCESS, success (no error) 
[33752.134725][ctx       none]=========vaQueryConfigEntrypoints ret = VA_STATUS_SUCCESS, success (no error) 
[33752.134726][ctx       none]=========vaQueryConfigEntrypoints ret = VA_STATUS_SUCCESS, success (no error) 
[33752.160574][ctx       none]==========va_TraceTerminate
[33752.160603][ctx       none]=========vaTerminate ret = VA_STATUS_SUCCESS, success (no error) 


```