### PR TITLE
va/win32: rely on compiler to define link names

### DIFF
--- a/va/libva.def
+++ b/va/libva.def
@@ -1,4 +1,3 @@
-LIBRARY va
 EXPORTS
     vaInitialize
     vaErrorStr

--- a/va/libva_win32.def
+++ b/va/libva_win32.def
@@ -1,3 +1,2 @@
-LIBRARY va_win32
 EXPORTS
     vaGetDisplayWin32


### PR DESCRIPTION
Fixes: #711

This removes hardcoding library names to link applications against. Hardcode was set to be va.dll while mingw produces library with lib prefix, i.e. libva.dll. This causes missing libraries in link dependencies with obvious workaround to `cp libva.dll va.dll`.