### PR TITLE
change the try order of DRI2 and DRI3

### DIFF
--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -77,10 +77,9 @@ static VAStatus va_DisplayContextGetDriverNames(
 {
     VAStatus vaStatus = VA_STATUS_ERROR_UNKNOWN;
 
-    if (!getenv("LIBVA_DRI3_DISABLE"))
+    vaStatus = va_DRI2_GetDriverNames(pDisplayContext, drivers, num_drivers);
+    if (!getenv("LIBVA_DRI3_DISABLE") && (vaStatus != VA_STATUS_SUCCESS))
         vaStatus = va_DRI3_GetDriverNames(pDisplayContext, drivers, num_drivers);
-    if (vaStatus != VA_STATUS_SUCCESS)
-        vaStatus = va_DRI2_GetDriverNames(pDisplayContext, drivers, num_drivers);
 #ifdef HAVE_NVCTRL
     if (vaStatus != VA_STATUS_SUCCESS)
         vaStatus = va_NVCTRL_GetDriverNames(pDisplayContext, drivers, num_drivers);


### PR DESCRIPTION
try DRI2 firstly, if suecess, it could detect driver name , also could use vaPutSurfaces.
if failed , try DRI3, it only support driver name detection could not use vaPutSurfaces.

if there are both DRI2 and DRI3
it could ensure vaPutSurfaces work