### PR TITLE
Mem leaks

### DIFF
--- a/va/va.c
+++ b/va/va.c
@@ -705,7 +705,7 @@ static VAStatus va_new_opendriver(VADisplay dpy)
         num_drivers = 1;
 
         va_infoMessage(dpy, "User %srequested driver '%s'\n",
-                       ctx->override_driver_name ? "" : "environment variable",
+                       ctx->override_driver_name ? "" : "environment variable ",
                        driver);
     }
 

--- a/va/va.c
+++ b/va/va.c
@@ -698,6 +698,9 @@ static VAStatus va_new_opendriver(VADisplay dpy)
         const char *driver = ctx->override_driver_name ?
                              ctx->override_driver_name : driver_name_env;
 
+        for (unsigned int i = 0; i < num_drivers; i++)
+            free(drivers[i]);
+
         drivers[0] = strdup(driver);
         num_drivers = 1;
 


### PR DESCRIPTION
- va: don't leak driver names, when override is set
- va: add missing space in the env.var override info message

No rocket science here ;-)