### PR TITLE
api: extend va_deprecate to modern c/c++ and MSVC

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -86,13 +86,22 @@
 extern "C" {
 #endif
 
-#if defined(__GNUC__) && !defined(__COVERITY__)
+#if defined(__cplusplus) && __cplusplus >= 201402L
+#define va_deprecated [[deprecated]]
+#define va_deprecated_enum [[deprecated]]
+#elif __STDC__ && __STDC_VERSION__ >= 202311L
+#define va_deprecated [[deprecated]]
+#define va_deprecated_enum [[deprecated]]
+#elif defined(__GNUC__) && !defined(__COVERITY__)
 #define va_deprecated __attribute__((deprecated))
 #if __GNUC__ >= 6
 #define va_deprecated_enum va_deprecated
 #else
 #define va_deprecated_enum
 #endif
+#elif defined(_MSC_VER)
+#define va_deprecated __declspec(deprecated)
+#define va_deprecated_enum
 #else
 #define va_deprecated
 #define va_deprecated_enum


### PR DESCRIPTION
Since libva was ported to Windows we should extend va_deprecate to work for MSVC where possible. Otherwise there might be confisions on which API is or is not deprecated.

We also can use advantages of modern c/c++ standards providing deprecating attributes.