### PR TITLE
va: Fix -Wl,--version-script check with LLD 17

### DIFF
--- a/conftest.syms
+++ b/conftest.syms
@@ -1,0 +1,6 @@
+VERSION_1 {
+    global:
+        main;
+    local:
+        *;
+};

--- a/meson.build
+++ b/meson.build
@@ -87,6 +87,12 @@ dl_dep = cc.find_library('dl', required : false)
 WITH_DRM = not get_option('disable_drm') and (host_machine.system() != 'windows')
 libdrm_dep = dependency('libdrm', version : '>= 2.4.60', required : (host_machine.system() != 'windows'))
 
+ld_supports_version_script = cc.links(
+  'int main() { return 0; }',
+  name : '-Wl,--version-script',
+  args : ['-shared', '-Wl,--version-script,' + '@0@/@1@'.format(meson.current_source_dir(), 'conftest.syms')]
+)
+
 WITH_X11 = false
 if get_option('with_x11') != 'no'
   x11_dep = dependency('x11', required : get_option('with_x11') == 'yes')

--- a/va/meson.build
+++ b/va/meson.build
@@ -60,7 +60,7 @@ libva_sym_arg = '-Wl,-version-script,' + '@0@/@1@'.format(meson.current_source_d
 
 libva_link_args = []
 libva_link_depends = []
-if cc.links('', name: '-Wl,--version-script', args: ['-shared', libva_sym_arg])
+if ld_supports_version_script
   libva_link_args = libva_sym_arg
   libva_link_depends = libva_sym
 endif


### PR DESCRIPTION
In the upcoming LLD 17 (and previously in LLD 16.0.0, but reverted in 16.0.1), --no-undefined-version is becoming the default behavior. This causes the configure check for --version-scripts support to fail due to the symbols in the version script not being defined, which will cause the version script to not be used, and the build will fail due to --no-undefined-version. This commit adds '-Wl,--undefined-version' to the args of the configure check.