### PR TITLE
vaGetDeviceNames inspired fixes and documentation

### DIFF
--- a/va/va.c
+++ b/va/va.c
@@ -674,10 +674,6 @@ static VAStatus va_new_opendriver(VADisplay dpy)
     const char *driver_name_env;
     VADriverContextP ctx;
 
-    /* XXX: Temporary dummy return, until all platforms are converted */
-    if (!pDisplayContext->vaGetDriverNames)
-        return VA_STATUS_ERROR_INVALID_PARAMETER;
-
     /* XXX: The order is bonkers - env var should take highest priority, then
      * override (which ought to be nuked) than native. It's not possible atm,
      * since the DPY connect/init happens during the GetDriverNames.

--- a/va/va.c
+++ b/va/va.c
@@ -687,9 +687,6 @@ static VAStatus va_new_opendriver(VADisplay dpy)
         /* Print and error yet continue, as per the above ordering note */
         va_errorMessage(dpy, "vaGetDriverNames() failed with %s\n", vaErrorStr(vaStatus));
         num_drivers = 0;
-    } else if (num_drivers > ARRAY_SIZE(drivers)) {
-        va_errorMessage(dpy, "DRIVER BUG: vaGetDriverNames() provides too many drivers\n");
-        num_drivers = ARRAY_SIZE(drivers);
     }
 
     ctx = CTX(dpy);

--- a/va/va_backend.h
+++ b/va/va_backend.h
@@ -663,6 +663,7 @@ struct VADisplayContext {
         VADisplayContextP ctx
     );
 
+    /* Deprecated */
     VAStatus(*vaGetDriverName)(
         VADisplayContextP ctx,
         char **driver_name
@@ -677,17 +678,36 @@ struct VADisplayContext {
     void *error_callback_user_context;
     VAMessageCallback info_callback;
     void *info_callback_user_context;
+
+    /* Deprecated */
     VAStatus(*vaGetNumCandidates)(
         VADisplayContextP ctx,
         int * num_candidates
     );
 
+    /* Deprecated */
     VAStatus(*vaGetDriverNameByIndex)(
         VADisplayContextP ctx,
         char **driver_name,
         int  candidate_index
     );
 
+    /**
+     * \brief Callback to get an array of driver names.
+     *
+     *
+     * The caller must provide a num_drivers
+     * This structure is allocated from libva with calloc().
+     *
+     * @param drivers  An num_drivers sized array of null terminated strings.
+     *                 The array is managed my the caller. The callee will
+     *                 populate the individual driver name strings and the
+     *                 caller must free them.
+     * @param num_driver The number of driver strings contained within drivers.
+     *                   The caller must set that to the size of the drivers
+     *                   array, where the callee will update the value to
+     *                   min(caller num_driver, num_drivers_support).
+     */
     VAStatus(*vaGetDriverNames)(
         VADisplayContextP ctx,
         char **drivers,

--- a/va/va_backend.h
+++ b/va/va_backend.h
@@ -670,6 +670,7 @@ struct VADisplayContext {
 
     void *opaque; /* opaque for display extensions (e.g. GLX) */
     void *vatrace; /* opaque for VA trace context */
+    /* Deprecated */
     void *vafool; /* opaque for VA fool context */
 
     VAMessageCallback error_callback;

--- a/va/x11/va_dri2.c
+++ b/va/x11/va_dri2.c
@@ -456,11 +456,9 @@ VAStatus va_DRI2_GetDriverNames(
         if (strcmp(map[i].dri_driver, dri_driver) == 0) {
             const char * const *va_drivers = map[i].va_driver;
 
-            while (va_drivers[count]) {
-                if (count < MAX_NAMES && count < *num_drivers)
-                    drivers[count] = strdup(va_drivers[count]);
-                count++;
-            }
+            for (; count < MAX_NAMES && va_drivers[count] && count < *num_drivers; count++)
+                drivers[count] = strdup(va_drivers[count]);
+
             break;
         }
     }


### PR DESCRIPTION
Effectively a follow-up on https://github.com/intel/libva/pull/731

- va/backend: document the vaGetDriver* APIs
- x11/dri2: limit the array handling to avoid out of range access
- va: remove unreachable "DRIVER BUG"
- va: drop no longer applicable vaGetDriverNames check

There a couple of unrelated fixes, noticed while browsing through:
 - win32: remove duplicate adapter_luid entry - @sivileri can you have a quick look?
 - va/backend: annotate vafool as deprecated