### PR TITLE
Added Q416 fourcc for 16-bit YUV 4:4:4 planar format

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -4583,6 +4583,11 @@ VAStatus vaSyncBuffer(
  * Four bytes per pixel: X, Y, U, V.
  */
 #define VA_FOURCC_XYUV          0x56555958
+/** Q416: three-plane 16-bit YUV 4:4:4.
+ *
+ * The three planes contain Y, U and V respectively.
+ */
+#define VA_FOURCC_Q416          0x36313451
 
 /* byte order */
 #define VA_LSB_FIRST        1


### PR DESCRIPTION
Needed to support YUV 4:4:4 10 and 12 bits HEVC decoding for https://github.com/elFarto/nvidia-vaapi-driver.
Nvidia proprietary driver uses planar YUV 4:4:4 for 16 bits surfaces according to [cuviddec.h](https://github.com/NVIDIA/DALI/blob/7268fe15c50db664b4df5226b66cb46e717f46be/dali/operators/reader/loader/video/nvdecode/cuviddec.h#L91).