### PR TITLE
refine encode segment id map buffer

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -1491,6 +1491,19 @@ typedef union _VAConfigAttribValEncPerBlockControl {
 /** \brief Driver supports decode processing rate report  */
 #define VA_PROCESSING_RATE_DECODE                     0x00000002
 /**@}*/
+
+/** @name segment ID map block size */
+/**@{*/
+/** \brief each segmentID represent a 16x16 block */
+#define VA_SEGID_BLOCK_16X16                          0
+/** \brief each segmentID represent a 32x32 block */
+#define VA_SEGID_BLOCK_32X32                          1
+/** \brief each segmentID represent a 64x64 block */
+#define VA_SEGID_BLOCK_64X64                          2
+/** \brief each segmentID represent a 8x8 block */
+#define VA_SEGID_BLOCK_8X8                            3
+/**@}*/
+
 /**
  * if an attribute is not applicable for a given
  * profile/entrypoint pair, then set the value to the following

--- a/va/va.h
+++ b/va/va.h
@@ -1053,6 +1053,14 @@ typedef enum {
      * columns supported for encoding with tile support.
      */
     VAConfigAttribEncMaxTileCols        = 57,
+    /**
+     * \brief VP9 encoding attribute. Read-only.
+     *
+     * This attribute exposes a number of capabilities of the underlying
+     * VP9 implementation. The attribute value is partitioned into fields as defined in the
+     * VAConfigAttribValEncVP9 union.
+     */
+    VAConfigAttribEncVP9                = 58,
     /**@}*/
     VAConfigAttribTypeMax
 } VAConfigAttribType;

--- a/va/va_enc_av1.h
+++ b/va/va_enc_av1.h
@@ -148,8 +148,10 @@ typedef union _VAConfigAttribValEncAV1Ext1 {
          */
         uint32_t interpolation_filter          : 5;
         /**
-         * \brief Min segmentId block size accepted.
+         * \brief segmentId block size accepted.
          * Application need to send seg_id_block_size in PPS equal or larger than this value.
+         * one bit represent one block size defined as VA_SEGID_BLOCKXXXX
+         * should be (1 << VA_SEGID_BLOCKXXX | 1 << VA_SEGID_BLOCKXXX ... )
          */
         uint32_t min_segid_block_size_accepted : 8;
         /**
@@ -667,10 +669,7 @@ typedef struct  _VAEncPictureParameterBufferAV1 {
     } picture_flags;
 
     /** \brief Block size for each Segment ID in Segment Map.
-     *  0: 16x16 block size, default value;
-     *  1: 32x32 block size;
-     *  2: 64x64 block size;
-     *  3: 8x8 block size.
+     *  should be \c VA_SEGID_BLOCK_XXXX;
      */
     uint8_t     seg_id_block_size;
 

--- a/va/va_enc_vp9.h
+++ b/va/va_enc_vp9.h
@@ -595,8 +595,10 @@ typedef struct _VAEncMiscParameterTypeVP9PerSegmantParam {
  * \brief VP9 Block Segmentation ID Buffer
  *
  * The application provides a buffer of VAEncMacroblockMapBufferType containing
- * the initial segmentation id for each 8x8 block, one byte each, in raster scan order.
- * Rate control may reassign it.  For example, a 640x480 video, the buffer has 4800 entries.
+ * the initial segmentation id for each block, block size is specified by seg_id_block_size
+ * in VAEncPictureParameterBufferVP9  , one byte each, in raster scan order.
+ * Rate control may reassign it.  For example, a 640x480 video, seg_id_block_size is
+ * VA_SEGID_BLOCK_16X16 , the buffer has 1200 entries.
  * The value of each entry should be in the range [0..7], inclusive.
  * If segmentation is not enabled, the application does not need to provide it.
  */

--- a/va/va_enc_vp9.h
+++ b/va/va_enc_vp9.h
@@ -507,8 +507,16 @@ typedef struct  _VAEncPictureParameterBufferVP9 {
      */
     uint32_t    skip_frames_size;
 
+    /** \brief Block size for each Segment ID in Segment Map.
+     *  This specify the granularity of media driver of reading and processing the segment map.
+     *  value should be VA_SEGID_BLOCK_XXX
+     */
+    uint8_t     seg_id_block_size;
+
+    uint8_t     va_reserved8[3];
+
     /** \brief Reserved bytes for future use, must be zero */
-    uint32_t    va_reserved[VA_PADDING_MEDIUM];
+    uint32_t    va_reserved[VA_PADDING_MEDIUM - 1];
 } VAEncPictureParameterBufferVP9;
 
 
@@ -593,6 +601,32 @@ typedef struct _VAEncMiscParameterTypeVP9PerSegmantParam {
  * If segmentation is not enabled, the application does not need to provide it.
  */
 
+
+/** \brief Attribute value for VAConfigAttribEncVP9. */
+typedef union _VAConfigAttribValEncVP9 {
+    struct {
+        /**
+         * \brief segmentId block size accepted.
+         * This is the granularity of segmentation map.
+         * one bit represent one block size defined as VA_SEGID_BLOCKXXXX
+         * should be (1 << VA_SEGID_BLOCKXXX | 1 << VA_SEGID_BLOCKXXX ... )
+         */
+        uint32_t seg_id_block_size             : 8;
+
+        /**
+         * \brief Type of segment feature supported.
+         * (segment_feature_support & 0x01) == 1: SEG_LVL_ALT_Q is supported, 0: not.
+         * (segment_feature_support & 0x02) == 1: SEG_LVL_ALT_L is supported, 0: not.
+         * (segment_feature_support & 0x04) == 1: SEG_LVL_REF_FRAME is supported, 0: not.
+         * (segment_feature_support & 0x08) == 1: SEG_LVL_SKIP is supported, 0: not.
+         */
+        uint32_t segment_feature_support       : 4;
+
+        /** \brief Reserved bits for future, must be zero. */
+        uint32_t reserved                      : 20;
+    } bits;
+    uint32_t value;
+} VAConfigAttribValEncVP9;
 
 /**@}*/
 

--- a/va/va_str.c
+++ b/va/va_str.c
@@ -153,6 +153,7 @@ const char *vaConfigAttribTypeStr(VAConfigAttribType configAttribType)
         TOSTR(VAConfigAttribEncPerBlockControl);
         TOSTR(VAConfigAttribEncMaxTileRows);
         TOSTR(VAConfigAttribEncMaxTileCols);
+        TOSTR(VAConfigAttribEncVP9);
     case VAConfigAttribTypeMax:
         break;
     }


### PR DESCRIPTION
attention: these change will break backward compatibility, the pre-assumption is no one is using them besides intel media driver and intel oneVPL runtime, if there are other customer,  it should be risky 
so, please help to check whether there are somebody are using segment id map buffer for avc or vp9 encoding. 