### PR TITLE
va_win32: Fix debug build break

### DIFF
--- a/va/win32/va_win32.c
+++ b/va/win32/va_win32.c
@@ -183,9 +183,9 @@ VADisplay vaGetDisplayWin32(
         LoadDriverNameFromRegistry(adapter_luid, pWin32Ctx);
 #ifdef _DEBUG
         if (pWin32Ctx->registry_driver_available_flag) {
-            fprintf(stderr, "VA_Win32: Found driver %s in the registry for LUID %ld %ld \n", pWin32Ctx->registry_driver_name, adapter_luid.LowPart, adapter_luid.HighPart);
+            fprintf(stderr, "VA_Win32: Found driver %s in the registry for LUID %ld %ld \n", pWin32Ctx->registry_driver_name, adapter_luid->LowPart, adapter_luid->HighPart);
         } else {
-            fprintf(stderr, "VA_Win32: Couldn't find a driver in the registry for LUID %ld %ld. Using default driver: %s \n", adapter_luid.LowPart, adapter_luid.HighPart, VAAPI_DEFAULT_DRIVER_NAME);
+            fprintf(stderr, "VA_Win32: Couldn't find a driver in the registry for LUID %ld %ld. Using default driver: %s \n", adapter_luid->LowPart, adapter_luid->HighPart, VAAPI_DEFAULT_DRIVER_NAME);
         }
 #endif // _DEBUG
     }


### PR DESCRIPTION
Fix debug build break:

```
[3/9] Compiling C object va/va_win32.dll.p/win32_va_win32.c.obj
FAILED: va/va_win32.dll.p/win32_va_win32.c.obj
"cl" "-Iva\va_win32.dll.p" "-Iva" "-I..\va" "-I." "-I.." "/MDd" "/nologo" "/showIncludes" "/utf-8" "/W2" "/Od" "/Zi" "-DLIBVA_MAJOR_VERSION=2" "/Fdva\va_win32.dll.p\win32_va_win32.c.pdb" /Fova/va_win32.dll.p/win32_va_win32.c.obj "/c" ../va/win32/va_win32.c
../va/win32/va_win32.c(186): error C2231: '.LowPart': left operand points to 'struct', use '->'
../va/win32/va_win32.c(186): error C2231: '.HighPart': left operand points to 'struct', use '->'
../va/win32/va_win32.c(188): error C2231: '.LowPart': left operand points to 'struct', use '->'
../va/win32/va_win32.c(188): error C2231: '.HighPart': left operand points to 'struct', use '->'
[5/9] Compiling C object va/va.dll.p/va_trace.c.obj
ninja: build stopped: subcommand failed.
```

Fixes: 484f128 ("win32: remove duplicate adapter_luid entry")

CC @dvrogozh @evelikov @XinfengZhang 