### PR TITLE
va: export symbol vaMapBuffer2 for Windows

### DIFF
--- a/va/libva.def
+++ b/va/libva.def
@@ -32,6 +32,7 @@ EXPORTS
     vaGetDisplayAttributes
     vaGetImage
     vaMapBuffer
+    vaMapBuffer2
     vaMaxNumDisplayAttributes
     vaMaxNumImageFormats
     vaMaxNumSubpictureFormats


### PR DESCRIPTION
This new added api should be exported otherwise it will cause link issues.