### PR TITLE
ci: update to vmactions/freebsd-vm from v0 to v1

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -4,12 +4,12 @@ on: [push, pull_request]
 
 jobs:
   freebsd:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     steps:
     - name: 'Checkout'
       uses: actions/checkout@v4
     - name: 'Install prerequisites and build'
-      uses: vmactions/freebsd-vm@v0
+      uses: vmactions/freebsd-vm@v1
       with:
         prepare: |
           pkg install -y meson pkgconf libdrm libXext libXfixes wayland


### PR DESCRIPTION
As noted in the action v1 release note, action was rewritten to use qemu and libvirt which requires switch from macos to ubuntu runners.