### PR TITLE
va: export symbol vaGetLibFunc for Windows

### DIFF
--- a/va/libva.def
+++ b/va/libva.def
@@ -84,3 +84,4 @@ EXPORTS
     vaStatusStr
     vaSyncSurface2
     vaDisplayIsValid
+    vaGetLibFunc


### PR DESCRIPTION
Add symbol for exporting existing VA vaGetLibFunc function to .def file

Fixes #782
