### PR TITLE
va: fix handling when all wayland backends fail

### DIFF
--- a/va/wayland/va_wayland.c
+++ b/va/wayland/va_wayland.c
@@ -133,11 +133,9 @@ vaGetDisplayWl(struct wl_display *display)
 
     for (i = 0; g_backends[i].create != NULL; i++) {
         if (g_backends[i].create(pDisplayContext))
-            break;
+            return (VADisplay)pDisplayContext;
         g_backends[i].destroy(pDisplayContext);
     }
-
-    return (VADisplay)pDisplayContext;
 
 error:
     va_DisplayContextDestroy(pDisplayContext);


### PR DESCRIPTION
when all backend failed vaGetDisplayWl will just return a context that was already destroyed. This leads to crashes if downstream tries to use the context.

I'm not familiar with the unit test infra but it may make sense to add a unit test here..