### PR TITLE
wayland: fix segfault when all backends fail

### DIFF
--- a/va/wayland/va_wayland.c
+++ b/va/wayland/va_wayland.c
@@ -133,11 +133,9 @@ vaGetDisplayWl(struct wl_display *display)
 
     for (i = 0; g_backends[i].create != NULL; i++) {
         if (g_backends[i].create(pDisplayContext))
-            break;
+            return (VADisplay)pDisplayContext;
         g_backends[i].destroy(pDisplayContext);
     }
-
-    return (VADisplay)pDisplayContext;
 
 error:
     va_DisplayContextDestroy(pDisplayContext);


### PR DESCRIPTION
When all Wayland backends fail, vaGetDisplayWl() would still return a half-constructed display context, resulting in a sefault in va_DRM_GetDrmDriverName() later on when trying to access ctx->drm_state->fd.

Instead, cleanup and return NULL.