### PR TITLE
meson: create dist archives suitable for building with configure, too

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -36,7 +36,7 @@ cd "$srcdir"
 
 mkdir -p m4
 
-AUTORECONF=`which autoreconf`
+AUTORECONF=`command -v autoreconf`
 if test -z $AUTORECONF; then
     echo "*** No autoreconf found ***"
     exit 1

--- a/autogen.sh
+++ b/autogen.sh
@@ -23,6 +23,13 @@
 
 PROJECT="libva"
 
+# for `meson dist`
+if test -z "$srcdir"; then
+    srcdir="$MESON_PROJECT_DIST_ROOT"
+    test -n "$srcdir" || srcdir="$MESON_DIST_ROOT"
+    test -n "$srcdir" && NOCONFIGURE=1
+fi
+
 test -n "$srcdir" || srcdir="`dirname \"$0\"`"
 test -n "$srcdir" || srcdir=.
 

--- a/meson.build
+++ b/meson.build
@@ -157,3 +157,5 @@ doxygen = find_program('doxygen', required: false)
 if get_option('enable_docs') and doxygen.found()
   subdir('doc')
 endif
+
+meson.add_dist_script('./autogen.sh')


### PR DESCRIPTION
Run autogen.sh as a dist script while creating the tarball. Also update autogen.sh to detect when it is being run from `meson dist`, and use that as the srcdir.