### PR TITLE
va: add VASurfaceAttribAlignmentSize

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -1699,6 +1699,15 @@ typedef enum {
      * when importing an existing buffer.
      */
     VASurfaceAttribDRMFormatModifiers,
+    /** \brief width and height log2 aligment in pixels (int, read-only)
+     *
+     * For special HW requirement used in some codecs, if
+     * VASurfaceAttribAlignmentSize is not implemented in the driver, then
+     * the surface_width and surface_height should keep the original logic
+     * without any modification, this is an add-on requirement to
+     * surface_width and surface_height.
+     */
+    VASurfaceAttribAlignmentSize,
     /** \brief Number of surface attributes. */
     VASurfaceAttribCount
 } VASurfaceAttribType;
@@ -1727,6 +1736,20 @@ typedef struct _VASurfaceAttrib {
 /** \brief User pointer memory type is supported. */
 #define VA_SURFACE_ATTRIB_MEM_TYPE_USER_PTR     0x00000004
 /**@}*/
+/**
+ * \brief VASurfaceAttribAlignmentStruct structure for
+ * the VASurfaceAttribAlignmentSize attribute.
+ */
+typedef union _VASurfaceAttribAlignmentStruct {
+    struct {
+        /** \brief log2 width aligment */
+        uint32_t log2_width_alignment  : 4;
+        /** \brief log2 height aligment */
+        uint32_t log2_height_alignment : 4;
+        uint32_t reserved              : 24;
+    } bits;
+    uint32_t value;
+} VASurfaceAttribAlignmentStruct;
 
 /**
  * \brief VASurfaceAttribExternalBuffers structure for


### PR DESCRIPTION
Due to different HW implementation, the
surface could require a different alignment size
rather than the default ones, here introduces
a new VASurfaceAttribute, alignment size, which
contains two variables log2_width_alignment
and log2_height_alignment, each has 4 bits,
and the alignment needs to be left shifted
2**size from the application side.

The alignment is in the powers of 2 and
range in [2**0, ... 2**15] = [1, 2, 4, 8, ... 32768]

And this alignment should be met when creating
context as an add-on requirement. If not
implemented, the existing/default alignment
logic will be used.