### PR TITLE
va: Add encoding tuning mode

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -1050,6 +1050,15 @@ typedef enum {
      * columns supported for encoding with tile support.
      */
     VAConfigAttribEncMaxTileCols        = 57,
+    /**
+     * \brief Encoding tuning mode attribute. Read-only.
+     *
+     * This attribute conveys whether the driver supports different tuning modes
+     * for encoding. The attribute value is any combination of VA_ENC_TUNING_MODE_XXX.
+     *
+     * The tuning mode is passed to the driver using VAEncMiscParameterBufferQualityLevel.
+     */
+    VAConfigAttribEncTuningMode         = 58,
     /**@}*/
     VAConfigAttribTypeMax
 } VAConfigAttribType;
@@ -2707,6 +2716,13 @@ typedef struct _VAEncMiscParameterBufferMultiPassFrameSize {
     unsigned long           va_reserved[VA_PADDING_LOW];
 } VAEncMiscParameterBufferMultiPassFrameSize;
 
+/** \brief Default tuning mode */
+#define VA_ENC_TUNING_MODE_DEFAULT                      0x00000000
+/** \brief Compromise quality to lower the latency of video encode operations */
+#define VA_ENC_TUNING_MODE_LOW_LATENCY                  0x00000001
+/** \brief Compromise quality for lowest latency of video encode operations */
+#define VA_ENC_TUNING_MODE_ULTRA_LOW_LATENCY            0x00000002
+
 /**
  * \brief Encoding quality level.
  *
@@ -2717,6 +2733,8 @@ typedef struct _VAEncMiscParameterBufferMultiPassFrameSize {
  * attribute. A lower value means higher quality, and a value of 1 represents the highest
  * quality. The quality level setting is used as a trade-off between quality and speed/power
  * consumption, with higher quality corresponds to lower speed and higher power consumption.
+ * The number of supported tuning modes can be queried through the VAConfigAttribEncTuningMode
+ * attribute.
  */
 typedef struct _VAEncMiscParameterBufferQualityLevel {
     /** \brief Encoding quality level setting. When set to 0, default quality
@@ -2724,8 +2742,11 @@ typedef struct _VAEncMiscParameterBufferQualityLevel {
      */
     uint32_t                quality_level;
 
+    /** \brief Encoding tuning mode setting, see VA_ENC_TUNING_MODE_XXX */
+    uint32_t                tuning_mode;
+
     /** \brief Reserved bytes for future use, must be zero */
-    uint32_t                va_reserved[VA_PADDING_LOW];
+    uint32_t                va_reserved[VA_PADDING_LOW - 1];
 } VAEncMiscParameterBufferQualityLevel;
 
 /**

--- a/va/va_str.c
+++ b/va/va_str.c
@@ -151,6 +151,7 @@ const char *vaConfigAttribTypeStr(VAConfigAttribType configAttribType)
         TOSTR(VAConfigAttribEncPerBlockControl);
         TOSTR(VAConfigAttribEncMaxTileRows);
         TOSTR(VAConfigAttribEncMaxTileCols);
+        TOSTR(VAConfigAttribEncTuningMode);
     case VAConfigAttribTypeMax:
         break;
     }

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -3642,6 +3642,7 @@ static void va_TraceVAEncMiscParameterBuffer(
 
         va_TraceMsg(trace_ctx, "\t--VAEncMiscParameterBufferQualityLevel\n");
         va_TraceMsg(trace_ctx, "\tquality_level = %d\n", p->quality_level);
+        va_TraceMsg(trace_ctx, "\ttuning_mode = %d\n", p->tuning_mode);
         break;
     }
     case VAEncMiscParameterTypeROI: {


### PR DESCRIPTION
This provides a hint to driver about the requested encode tuning in addition to quality level number. It can be used by hardware encoders that supports low latency encoding as a special mode instead of setting the lowest quality level.

The tuning modes matches Vulkan VkVideoEncodeTuningModeKHR, except lossless which I don't think makes sense here.

Motivation is AMD VCN encoder which has low latency mode that should be enabled for usecases like realtime game streaming, and it works with all presets (quality levels), not only with the fastest preset.