### PR TITLE
deprecate VA_RC_MB

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -1107,7 +1107,8 @@ typedef struct _VAConfigAttrib {
  *  adjusts QP at a frame and MB level based on motion to improve subjective quality. */
 #define VA_RC_ICQ           0x00000040
 /** \brief Macroblock based rate control.  Per MB control is decided
- *  internally in the encoder. It may be combined with other RC modes, except CQP. */
+ *  internally in the encoder. It may be combined with other RC modes, except CQP.
+ *  @deprecated , it is decided internally in driver, driver should enable/disable it internally*/
 #define VA_RC_MB                        0x00000080
 /** \brief Constant Frame Size, it is used for small tolerent  */
 #define VA_RC_CFS                       0x00000100

--- a/va/va.h
+++ b/va/va.h
@@ -1097,11 +1097,14 @@ typedef struct _VAConfigAttrib {
 #define VA_RC_CBR                       0x00000002
 /** \brief Variable bitrate. */
 #define VA_RC_VBR                       0x00000004
-/** \brief Video conference mode. */
+/** \brief Video conference mode.
+ *  special VBR mode designed to achieve better bit accuracy and quality
+ *  for video conference like contents */
 #define VA_RC_VCM                       0x00000008
 /** \brief Constant QP. */
 #define VA_RC_CQP                       0x00000010
-/** \brief Variable bitrate with peak rate higher than average bitrate. */
+/** \brief Variable bitrate with peak rate higher than average bitrate.
+ *  so , it allow HRD violation to get better quality */
 #define VA_RC_VBR_CONSTRAINED           0x00000020
 /** \brief Intelligent Constant Quality. Provided an initial ICQ_quality_factor,
  *  adjusts QP at a frame and MB level based on motion to improve subjective quality. */


### PR DESCRIPTION
A_RC_MB represent microblock based rate control
    but rate control implementation should be transparent to application.

    application does not care whether the BRC is microblock based or sub block based
    or frame based. it just care the quality and compression rate.