### PR TITLE
meson:remove autogen.sh from the meson script

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -158,4 +158,3 @@ if get_option('enable_docs') and doxygen.found()
   subdir('doc')
 endif
 
-meson.add_dist_script('./autogen.sh')


### PR DESCRIPTION
suppose no need to use customized package options. Fixes #804