### PR TITLE
va: limit to VAProfileAV1Profile2_420

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -542,7 +542,7 @@ typedef enum {
     VAProfileH264High10                 = 36,
     VAProfileVVCMain10                  = 37,
     VAProfileVVCMultilayerMain10        = 38,
-    VAProfileAV1Profile2                = 39
+    VAProfileAV1Profile2_420            = 39
 } VAProfile;
 
 /**

--- a/va/va_str.c
+++ b/va/va_str.c
@@ -64,7 +64,7 @@ const char *vaProfileStr(VAProfile profile)
         TOSTR(VAProfileHEVCSccMain444);
         TOSTR(VAProfileAV1Profile0);
         TOSTR(VAProfileAV1Profile1);
-        TOSTR(VAProfileAV1Profile2);
+        TOSTR(VAProfileAV1Profile2_420);
         TOSTR(VAProfileHEVCSccMain444_10);
         TOSTR(VAProfileProtected);
         TOSTR(VAProfileVVCMain10);

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -6775,7 +6775,7 @@ void va_TraceRenderPicture(
             break;
         case VAProfileAV1Profile0:
         case VAProfileAV1Profile1:
-        case VAProfileAV1Profile2:
+        case VAProfileAV1Profile2_420:
             for (j = 0; j < num_elements; j++) {
                 va_TraceMsg(trace_ctx, "\telement[%d] = \n", j);
 


### PR DESCRIPTION
Some hardwares do not support a full set of AV1 profile2, in this case use a subset instead. At the moment, VAProfileAV1Profile2_420 is for supporting 12-bit 4:2:0.