### PR TITLE
va: Add VAConfigAttribLowLatency

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -1063,6 +1063,19 @@ typedef enum {
      * VAConfigAttribValEncVP9 union.
      */
     VAConfigAttribEncVP9                = 58,
+
+    /**
+     * \brief Low latency context. Read/write.
+     *
+     * This attribute determines if the driver supports low latency context,
+     * through vaGetConfigAttributes(); and the user requests low latency context
+     * through vaCreateConfig(), if the driver supports it.
+     *
+     * Driver should minimize latency of operations, possibly at the cost of
+     * increased power use.
+     */
+    VAConfigAttribLowLatency = 59,
+
     /**@}*/
     VAConfigAttribTypeMax
 } VAConfigAttribType;

--- a/va/va_str.c
+++ b/va/va_str.c
@@ -156,6 +156,7 @@ const char *vaConfigAttribTypeStr(VAConfigAttribType configAttribType)
         TOSTR(VAConfigAttribEncMaxTileRows);
         TOSTR(VAConfigAttribEncMaxTileCols);
         TOSTR(VAConfigAttribEncVP9);
+        TOSTR(VAConfigAttribLowLatency);
     case VAConfigAttribTypeMax:
         break;
     }


### PR DESCRIPTION
Driver should minimize latency of operations, possibly at the cost of increased power use.

Mesa: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/32369