### PR TITLE
va_dec_av1: Add max_frame_width/height_minus_1

### DIFF
--- a/va/va_dec_av1.h
+++ b/va/va_dec_av1.h
@@ -621,10 +621,14 @@ typedef struct  _VADecPictureParameterBufferAV1 {
      */
     VAWarpedMotionParamsAV1 wm[7];
 
+    /** \brief corresponds to AV1 spec variable of the same name. */
+    uint16_t                max_frame_width_minus_1;
+    uint16_t                max_frame_height_minus_1;
+
     /**@}*/
 
     /** \brief Reserved bytes for future use, must be zero */
-    uint32_t                va_reserved[VA_PADDING_MEDIUM];
+    uint32_t                va_reserved[VA_PADDING_MEDIUM - 1];
 } VADecPictureParameterBufferAV1;
 
 

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -5421,6 +5421,9 @@ static void va_TraceVAPictureParameterBufferAV1(
         va_TraceMsg(trace_ctx, "\t\twm[%d].invalid = %d:\n", i, p->wm[i].invalid);
     }
 
+    va_TraceMsg(trace_ctx, "\tmax_frame_width_minus_1 = %d\n", p->max_frame_width_minus_1);
+    va_TraceMsg(trace_ctx, "\tmax_frame_height_minus_1 = %d\n", p->max_frame_height_minus_1);
+
     va_TraceMsg(trace_ctx, NULL);
 
     return;


### PR DESCRIPTION
AMD VCN needs this to correctly decode av1-1-b8-22-svc-L2T1 and av1-1-b8-22-svc-L2T2.