### PR TITLE
va: Add encoding QP map parameters

### DIFF
--- a/va/va_str.c
+++ b/va/va_str.c
@@ -155,6 +155,7 @@ const char *vaConfigAttribTypeStr(VAConfigAttribType configAttribType)
         TOSTR(VAConfigAttribEncMaxTileRows);
         TOSTR(VAConfigAttribEncMaxTileCols);
         TOSTR(VAConfigAttribEncVP9);
+        TOSTR(VAConfigAttribEncQPMap);
     case VAConfigAttribTypeMax:
         break;
     }
@@ -214,6 +215,7 @@ const char *vaBufferTypeStr(VABufferType bufferType)
         TOSTR(VASubPicBufferType);
         TOSTR(VATileBufferType);
         TOSTR(VASliceStructBufferType);
+        TOSTR(VAEncQPMapBufferType);
     case VABufferTypeMax:
         break;
     }

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -4542,6 +4542,13 @@ static void va_TraceVAEncMiscParameterBuffer(
         }
         break;
     }
+    case VAEncMiscParameterTypeQPMap: {
+        VAEncMiscParameterQPMap *p = (VAEncMiscParameterQPMap *)tmp->data;
+        va_TraceMsg(trace_ctx, "\t--VAEncMiscParameterQPMap\n");
+        va_TraceMsg(trace_ctx, "\t qp_map_mode = %d\n", p->qp_map_mode);
+        va_TraceMsg(trace_ctx, "\t qp_map = 0x%x\n", p->qp_map);
+        break;
+    }
     default:
         va_TraceMsg(trace_ctx, "Unknown VAEncMiscParameterBuffer(type = %d):\n", tmp->type);
         va_TraceVABuffers(dpy, context, buffer, type, size, num_elements, data);


### PR DESCRIPTION
QP map is a way of controlling block  
level QP(QI). Here it introduces two  
modes, delta and absolute. Delta mode  
will add/minus extra QP(QI) values  
based on CQP/RC's QP result, while  
absolute mode is directly using the QP  
(QI) values from QP map whenever possible;  
in absolute mode, since RC's adjustment  
on QP values not working, it is only  
valid in CQP mode, and RC adjustment  
in fact is processed externally.

Adding this is to support some encoding  
HWs, and provides a way of QP adjustment  
in addition to HW internal RC modes.

This defines VAEncMiscParameterQPMap  
structure and its corresponding attribute  
VAConfigAttribValEncQPMap, also defines  
the format of QP map element and buffer  
specification.

In contrast with FEI, QP map is an  
independent parameter set, and can be  
applied to the needed profiles, only  
with extra processing of the proposed  
misc parameters.