### PR TITLE
Add HEVC RefPicSetLtCurr and NumPocLtCurr picture parameters

### DIFF
--- a/va/va_dec_hevc.h
+++ b/va/va_dec_hevc.h
@@ -185,8 +185,15 @@ typedef struct  _VAPictureParameterBufferHEVC {
      */
     uint32_t                st_rps_bits;
 
+    /* Corresponds to the variables of same name as defined in section 8.3.2
+     * of the HEVC spec. Index into ReferenceFrames[]. */
+    uint8_t                 RefPicSetLtCurr[8];
+    uint8_t                 NumPocLtCurr;
+
+    uint8_t                 reserved[3];
+
     /** \brief Reserved bytes for future use, must be zero */
-    uint32_t                va_reserved[VA_PADDING_MEDIUM];
+    uint32_t                va_reserved[VA_PADDING_MEDIUM - 3];
 } VAPictureParameterBufferHEVC;
 
 /**

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -3580,6 +3580,12 @@ static void va_TraceVAPictureParameterBufferHEVC(
     va_TraceMsg(trace_ctx, "\tpps_tc_offset_div2 = %d\n", p->pps_tc_offset_div2);
     va_TraceMsg(trace_ctx, "\tnum_extra_slice_header_bits = %d\n", p->num_extra_slice_header_bits);
     va_TraceMsg(trace_ctx, "\tst_rps_bits = %d\n", p->st_rps_bits);
+    va_TraceMsg(trace_ctx, "\tRefPicSetLtCurr[8] = \n");
+    va_TraceMsg(trace_ctx, "");
+    for (i = 0; i < 8; i++)
+        va_TracePrint(trace_ctx, "\t%d", p->RefPicSetLtCurr[i]);
+    va_TracePrint(trace_ctx, "\n");
+    va_TraceMsg(trace_ctx, "\tNumPocLtCurr = %d\n", p->NumPocLtCurr);
 
     if (isRext && pRext) {
         va_TraceMsg(trace_ctx, "\trange_extension_pic_fields = %d\n", pRext->range_extension_pic_fields.value);


### PR DESCRIPTION
Corresponds to the variables of same name as defined in section 8.3.2 of the HEVC spec.

The RefPicSetStCurrBefore and RefPicSetStCurrAfter can be derived by sorting them, however there is no defined order for the RefPicSetLtCurr and thus it must be provided explicitly.

This is needed for AMD driver and also to match the DXVA and Vulkan Video interfaces.