### PR TITLE
trace: add missing trace fields for VAProcPipelineParameterBuffer

### DIFF
--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -6606,7 +6606,62 @@ va_TraceVAProcPipelineParameterBuffer(
         }
     }
 
-    /* FIXME: add other info later */
+    va_TraceMsg(trace_ctx, "\t  rotation_state = 0x%08x\n", p->rotation_state);
+
+    if (p->blend_state) {
+        va_TraceMsg(trace_ctx, "\t  blend_state\n");
+        va_TraceMsg(trace_ctx, "\t    flags = 0x%08x\n", p->blend_state->flags);
+        va_TraceMsg(trace_ctx, "\t    global_alpha = %f\n", p->blend_state->global_alpha);
+        va_TraceMsg(trace_ctx, "\t    min_luma = %f\n", p->blend_state->min_luma);
+        va_TraceMsg(trace_ctx, "\t    max_luma = %f\n", p->blend_state->max_luma);
+    } else {
+        va_TraceMsg(trace_ctx, "\t  blend_state = (NULL)\n");
+    }
+
+    va_TraceMsg(trace_ctx, "\t  mirror_state = 0x%08x\n", p->mirror_state);
+    va_TraceMsg(trace_ctx, "\t  num_additional_outputs = %d\n", p->num_additional_outputs);
+
+    if (p->num_additional_outputs) {
+        va_TraceMsg(trace_ctx, "\t  additional_outputs\n");
+
+        if (p->additional_outputs) {
+            /* only dump the first 5 additional outputs */
+            for (i = 0; i < p->num_additional_outputs && i < 5; i++) {
+                va_TraceMsg(trace_ctx, "\t    additional_outputs[%d] = 0x%08x\n", i, p->additional_outputs[i]);
+            }
+        } else {
+            for (i = 0; i < p->num_additional_outputs && i < 5; i++) {
+                va_TraceMsg(trace_ctx, "\t    additional_outputs[%d] = (NULL)\n", i);
+            }
+        }
+    }
+
+    va_TraceMsg(trace_ctx, "\t  input_surface_flag = 0x%08x\n", p->input_surface_flag);
+    va_TraceMsg(trace_ctx, "\t  output_surface_flag = 0x%08x\n", p->output_surface_flag);
+
+    va_TraceMsg(trace_ctx, "\t  input_color_properties\n");
+    va_TraceMsg(trace_ctx, "\t    chroma_sample_location = 0x%02x\n", p->input_color_properties.chroma_sample_location);
+    va_TraceMsg(trace_ctx, "\t    color_range = %d\n", p->input_color_properties.color_range);
+    va_TraceMsg(trace_ctx, "\t    colour_primaries = %d\n", p->input_color_properties.colour_primaries);
+    va_TraceMsg(trace_ctx, "\t    transfer_characteristics = %d\n", p->input_color_properties.transfer_characteristics);
+    va_TraceMsg(trace_ctx, "\t    matrix_coefficients = %d\n", p->input_color_properties.matrix_coefficients);
+
+    va_TraceMsg(trace_ctx, "\t  output_color_properties\n");
+    va_TraceMsg(trace_ctx, "\t    chroma_sample_location = 0x%02x\n", p->output_color_properties.chroma_sample_location);
+    va_TraceMsg(trace_ctx, "\t    color_range = %d\n", p->output_color_properties.color_range);
+    va_TraceMsg(trace_ctx, "\t    colour_primaries = %d\n", p->output_color_properties.colour_primaries);
+    va_TraceMsg(trace_ctx, "\t    transfer_characteristics = %d\n", p->output_color_properties.transfer_characteristics);
+    va_TraceMsg(trace_ctx, "\t    matrix_coefficients = %d\n", p->output_color_properties.matrix_coefficients);
+
+    va_TraceMsg(trace_ctx, "\t  processing_mode = %d\n", p->processing_mode);
+
+    if (p->output_hdr_metadata) {
+        va_TraceMsg(trace_ctx, "\t  output_hdr_metadata\n");
+        va_TraceMsg(trace_ctx, "\t    metadata_type = %d\n", p->output_hdr_metadata->metadata_type);
+        va_TraceMsg(trace_ctx, "\t    metadata_size = %d\n", p->output_hdr_metadata->metadata_size);
+    } else {
+        va_TraceMsg(trace_ctx, "\t  output_hdr_metadata = (NULL)\n");
+    }
 
     va_TraceMsg(trace_ctx, NULL);
 }

--- a/va/va_vpp.h
+++ b/va/va_vpp.h
@@ -909,7 +909,7 @@ typedef struct _VAProcPipelineParameterBuffer {
      * be queried with vaQueryVideoProcPipelineCaps().
      *
      * If this is set to VAProcColorStandardExplicit, the color properties
-     * are specified explicitly in surface_color_properties instead.
+     * are specified explicitly in input_color_properties instead.
      */
     VAProcColorStandardType surface_color_standard;
     /**


### PR DESCRIPTION
Example output:
```
[63581.184274][ctx 0xd0000000]  --VAProcPipelineParameterBuffer
[63581.184276][ctx 0xd0000000]    surface = 0x00000023
[63581.184277][ctx 0xd0000000]    surface_region
[63581.184277][ctx 0xd0000000]      x = 0
[63581.184278][ctx 0xd0000000]      y = 0
[63581.184279][ctx 0xd0000000]      width = 480
[63581.184280][ctx 0xd0000000]      height = 270
[63581.184280][ctx 0xd0000000]    surface_color_standard = 13
[63581.184281][ctx 0xd0000000]    output_region = (NULL)
[63581.184282][ctx 0xd0000000]    output_background_color = 0xff000000
[63581.184283][ctx 0xd0000000]    output_color_standard = 13
[63581.184284][ctx 0xd0000000]    pipeline_flags = 0x00000000
[63581.184285][ctx 0xd0000000]    filter_flags = 0x00000200
[63581.184286][ctx 0xd0000000]    num_filters = 0
[63581.184287][ctx 0xd0000000]    filters = (nil)
[63581.184288][ctx 0xd0000000]    num_forward_references = 0x00000000
[63581.184289][ctx 0xd0000000]    num_backward_references = 0x00000000
[63581.184290][ctx 0xd0000000]    rotation_state = 0x00000000
[63581.184291][ctx 0xd0000000]    blend_state = (NULL)
[63581.184291][ctx 0xd0000000]    mirror_state = 0x00000000
[63581.184292][ctx 0xd0000000]    num_additional_outputs = 0
[63581.184293][ctx 0xd0000000]    input_surface_flag = 0x00000000
[63581.184293][ctx 0xd0000000]    output_surface_flag = 0x00000000
[63581.184294][ctx 0xd0000000]    input_color_properties
[63581.184295][ctx 0xd0000000]      chroma_sample_location = 0x06
[63581.184296][ctx 0xd0000000]      color_range = 1
[63581.184296][ctx 0xd0000000]      colour_primaries = 1
[63581.184297][ctx 0xd0000000]      transfer_characteristics = 1
[63581.184298][ctx 0xd0000000]      matrix_coefficients = 1
[63581.184299][ctx 0xd0000000]    output_color_properties
[63581.184299][ctx 0xd0000000]      chroma_sample_location = 0x06
[63581.184300][ctx 0xd0000000]      color_range = 1
[63581.184301][ctx 0xd0000000]      colour_primaries = 1
[63581.184302][ctx 0xd0000000]      transfer_characteristics = 1
[63581.184302][ctx 0xd0000000]      matrix_coefficients = 0
[63581.184303][ctx 0xd0000000]    processing_mode = 0
[63581.184304][ctx 0xd0000000]    output_hdr_metadata = (NULL)
```

CC: @XinfengZhang @eromomon