### PR TITLE
[Decode] Add VC3 (DNxHD/DNxHR) decode profiles

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -543,7 +543,11 @@ typedef enum {
     VAProfileVVCMain10                  = 37,
     VAProfileVVCMultilayerMain10        = 38,
     VAProfileAV1Profile2                = 39,
-    VAProfileH264High422                = 40
+    VAProfileH264High422                = 40,
+    /** \brief VC3 HD profile (CBR, fixed resolutions 1920x1080 and 1280x720, DNxHD variants with CIDs 1235-1259). */
+    VAProfileVC3HD                      = 41,
+    /** \brief VC3 Resolution-Independent profile (VBR, flexible resolution up to 16384x16384, DNxHR variants with CIDs 1270-1274). */
+    VAProfileVC3RI                      = 42,
 } VAProfile;
 
 /**
@@ -5428,6 +5432,7 @@ VAStatus vaCopy(VADisplay dpy, VACopyObject * dst, VACopyObject * src, VACopyOpt
 #include <va/va_dec_vp9.h>
 #include <va/va_dec_av1.h>
 #include <va/va_dec_vvc.h>
+#include <va/va_dec_vc3.h>
 #include <va/va_enc_hevc.h>
 #include <va/va_fei_hevc.h>
 #include <va/va_enc_h264.h>


### PR DESCRIPTION
Added two new VAProfile enums for VC3 codec support:
- VAProfileVC3HD (41): For DNxHD variants with fixed resolutions (1920x1080, 1280x720) and CIDs 1235-1259
- VAProfileVC3RI (42): For DNxHR variants supporting flexible resolutions up to 16384x16384 and CIDs 1270-1274
Included va_dec_vc3.h header to enable VC3 decode functionality in VA-API.

[Internal]
Commit_Type: Feature
Platforms: Gen8_12, Xe_Hpm, Xe_Lpm, Xe2_Hpm, Xe2_Lpm, Xe3_Hpm, Xe3_Lpm, Xe3p_Hpm, Xe3p_Lpm, Xe4_Lpm
OS: Windows, Linux
Feature impact: Dec_VC3, API
Resolves: VSMGWL-82627
Related-to: VSMGWL-82627
Klocwork: N/A
TP_Passed: N/A
IP Scan: N/A