### PR TITLE
va: use secure_getenv instead of getenv in va_x11.c

### DIFF
--- a/va/compat_win32.h
+++ b/va/compat_win32.h
@@ -53,6 +53,7 @@ typedef unsigned int __uid_t;
 
 #if _MSC_VER
 #define getenv _getenv
+#undef secure_getenv
 #define secure_getenv _getenv
 #define HAVE_SECURE_GETENV
 inline char* _getenv(const char *varname)

--- a/va/va.c
+++ b/va/va.c
@@ -59,19 +59,6 @@
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
-#ifndef HAVE_SECURE_GETENV
-static char * secure_getenv(const char *name)
-{
-#if defined(__MINGW32__) || defined(__MINGW64__)
-    if (getuid() == geteuid())
-#else
-    if (getuid() == geteuid() && getgid() == getegid())
-#endif
-        return getenv(name);
-    else
-        return NULL;
-}
-#endif
 
 /*
  * read a config "env" for libva.conf or from environment setting

--- a/va/va_internal.h
+++ b/va/va_internal.h
@@ -29,6 +29,21 @@
 extern "C" {
 #endif
 
+#ifndef HAVE_SECURE_GETENV
+#ifdef _WIN32
+/* No setuid/setgid on Windows, secure_getenv is just getenv */
+#define secure_getenv getenv
+#else
+static inline char * secure_getenv(const char *name)
+{
+    if (getuid() == geteuid() && getgid() == getegid())
+        return getenv(name);
+    else
+        return NULL;
+}
+#endif
+#endif
+
 #define CTX(dpy) (((VADisplayContextP)dpy)->pDriverContext)
 #define CHECK_DISPLAY(dpy) if (!vaDisplayIsValid(dpy)) { return VA_STATUS_ERROR_INVALID_DISPLAY; }
 

--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -77,7 +77,7 @@ static VAStatus va_DisplayContextGetDriverNames(
 {
     VAStatus vaStatus = VA_STATUS_ERROR_UNKNOWN;
 
-    if (!getenv("LIBVA_DRI3_DISABLE"))
+    if (!secure_getenv("LIBVA_DRI3_DISABLE"))
         vaStatus = va_DRI3_GetDriverNames(pDisplayContext, drivers, num_drivers);
     if (vaStatus != VA_STATUS_SUCCESS)
         vaStatus = va_DRI2_GetDriverNames(pDisplayContext, drivers, num_drivers);


### PR DESCRIPTION
Move the secure_getenv fallback from va.c to va_internal.h so it is available to all internal callers, and replace the plain getenv call in va_x11.c with secure_getenv. This prevents environment variables from influencing behavior in setuid/setgid programs.