### PR TITLE
va/va_h264_enc: Add constrained flag for AVC encoder

### DIFF
--- a/va/va_enc_h264.h
+++ b/va/va_enc_h264.h
@@ -150,6 +150,8 @@ typedef struct _VAEncSequenceParameterBufferH264 {
     uint8_t   seq_parameter_set_id;
     /** \brief Same as the H.264 bitstream syntax element. */
     uint8_t   level_idc;
+    /** \brief Flags for constrained profiles. */
+    uint32_t    enc_constraint_set_flags;
     /** \brief Period between I frames. */
     uint32_t    intra_period;
     /** \brief Period between IDR frames. */

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -4338,6 +4338,7 @@ static void va_TraceVAEncSequenceParameterBufferH264(
 
     va_TraceMsg(trace_ctx, "\tseq_parameter_set_id = %d\n", p->seq_parameter_set_id);
     va_TraceMsg(trace_ctx, "\tlevel_idc = %d\n", p->level_idc);
+    va_TraceMsg(trace_ctx, "\tenc_constraint_set_flags = %u\n", p->enc_constraint_set_flags);
     va_TraceMsg(trace_ctx, "\tintra_period = %u\n", p->intra_period);
     va_TraceMsg(trace_ctx, "\tintra_idr_period = %u\n", p->intra_idr_period);
     va_TraceMsg(trace_ctx, "\tip_period = %u\n", p->ip_period);


### PR DESCRIPTION
In android, few testcases in CtsMediaV2TestCases module related to AVC encoder are failed, due to mismatch in profile. By adding enc_constraint_set_flags for AVC encoder, these constraint flags are set based on profile.