### PR TITLE
va: include <unistd.h> for getuid/getgid in secure_getenv fallback

### DIFF
--- a/va/va_internal.h
+++ b/va/va_internal.h
@@ -34,6 +34,7 @@ extern "C" {
 /* No setuid/setgid on Windows, secure_getenv is just getenv */
 #define secure_getenv getenv
 #else
+#include <unistd.h>
 static inline char * secure_getenv(const char *name)
 {
     if (getuid() == geteuid() && getgid() == getegid())


### PR DESCRIPTION
Fixes #888

On platforms like NetBSD (and other non-glibc systems), `getuid()`,
`geteuid()`, `getgid()`, and `getegid()` are not implicitly available —
they require an explicit `#include <unistd.h>` per POSIX. Without it,
the build fails with undefined function errors in the `secure_getenv`
fallback in `va/va_internal.h`.

The fix adds the missing include inside the `#else` branch that is
only compiled on non-Windows platforms where `HAVE_SECURE_GETENV` is
not defined.