### PR TITLE
va/trace: add microsecond resolution to trace file names

### DIFF
--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -551,18 +551,25 @@ static void FILE_NAME_SUFFIX(
     if (suffix_str)
         size = strlen(suffix_str);
 
-    if (left < (size + 8 + 10))
+    if (left < (size + 15 + 10))
         return;
 
     if (gettimeofday(&tv, NULL) == 0) {
+        /* Include microseconds so that multiple VADisplays created on the
+         * same thread within the same second get distinct trace file names.
+         * With only second resolution the names collide and each fopen(...,"w")
+         * truncates the previous one, losing traces (e.g. the encode trace when
+         * a decode and an encode display are initialized in the same second).
+         */
         sprintf(env_value + tmp,
-                ".%02d%02d%02d.",
+                ".%02d%02d%02d.%06ld.",
                 (unsigned int)(tv.tv_sec / 3600) % 24,
                 (unsigned int)(tv.tv_sec / 60) % 60,
-                (unsigned int)tv.tv_sec % 60);
+                (unsigned int)tv.tv_sec % 60,
+                (long)tv.tv_usec);
 
-        tmp += 8;
-        left -= 8;
+        tmp += 15;
+        left -= 15;
     }
 
     if (suffix_str) {


### PR DESCRIPTION
The trace log file name is composed as
"<prefix>.<HHMMSS>.thd-<thread_id>", which only has second resolution and no per-display component. Each VADisplay has its own log_files_manager, so when an application creates multiple VADisplays on the same thread within the same second (e.g. one for decode and one for encode), they all generate an identical file name and open it with fopen(..., "w") (O_TRUNC). The later opens truncate the earlier ones, so some traces are silently lost (commonly the encode trace).

Whether the traces collide is purely a matter of timing: if the displays straddle a second boundary the names differ and all traces survive, otherwise one clobbers the others. This made trace capture non-deterministic.

Include microseconds in the timestamp so displays initialized within the same second get distinct file names, and update the buffer length guard accordingly.